### PR TITLE
fix: prevent removing the last account

### DIFF
--- a/apps/extension/src/App.tsx
+++ b/apps/extension/src/App.tsx
@@ -2070,6 +2070,7 @@ function App() {
             onRevealSeedOpen();
           }}
           onAccountUpdated={loadAccounts}
+          totalAccounts={accounts.length}
         />
       </Suspense>
     </Box>

--- a/apps/extension/src/chrome/txHandlers.ts
+++ b/apps/extension/src/chrome/txHandlers.ts
@@ -1120,6 +1120,12 @@ export async function handleRemoveAccount(
       return { success: false, error: "Account not found" };
     }
 
+    // Prevent removing the last account
+    const allAccounts = await getAccounts();
+    if (allAccounts.length <= 1) {
+      return { success: false, error: "Cannot remove the last account" };
+    }
+
     // If it's a PK or seed phrase account, remove from vault
     if (account.type === "privateKey" || account.type === "seedPhrase") {
       await removeKeyFromVault(accountId);

--- a/apps/extension/src/components/AccountSettingsModal.tsx
+++ b/apps/extension/src/components/AccountSettingsModal.tsx
@@ -20,6 +20,7 @@ import {
   IconButton,
   Alert,
   AlertIcon,
+  Tooltip,
 } from "@chakra-ui/react";
 import { SettingsIcon, DeleteIcon, ViewIcon, WarningTwoIcon, EditIcon, ViewOffIcon, ArrowBackIcon, RepeatIcon } from "@chakra-ui/icons";
 import { useBauhausToast } from "@/hooks/useBauhausToast";
@@ -35,6 +36,7 @@ interface AccountSettingsModalProps {
   onRevealPrivateKey: (account: Account) => void;
   onRevealSeedPhrase: (account: Account) => void;
   onAccountUpdated: () => void;
+  totalAccounts: number;
 }
 
 type ModalView = "settings" | "confirmDelete" | "changeApiKey";
@@ -46,6 +48,7 @@ function AccountSettingsModal({
   onRevealPrivateKey,
   onRevealSeedPhrase,
   onAccountUpdated,
+  totalAccounts,
 }: AccountSettingsModalProps) {
   const toast = useBauhausToast();
   const [view, setView] = useState<ModalView>("settings");
@@ -931,23 +934,31 @@ function AccountSettingsModal({
                 </Button>
               )}
 
-              <Button
-                variant="ghost"
-                size="sm"
-                leftIcon={<DeleteIcon color="bauhaus.red" />}
-                onClick={() => setView("confirmDelete")}
-                justifyContent="flex-start"
-                color="bauhaus.red"
-                fontWeight="700"
-                border="2px solid transparent"
-                _hover={{
-                  bg: "red.50",
-                  borderColor: "bauhaus.red",
-                }}
-                w="full"
+              <Tooltip
+                label="Cannot remove the last account"
+                isDisabled={totalAccounts > 1}
+                placement="top"
+                hasArrow
               >
-                Remove Account
-              </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  leftIcon={<DeleteIcon color={totalAccounts <= 1 ? "gray.400" : "bauhaus.red"} />}
+                  onClick={() => setView("confirmDelete")}
+                  justifyContent="flex-start"
+                  color={totalAccounts <= 1 ? "gray.400" : "bauhaus.red"}
+                  fontWeight="700"
+                  border="2px solid transparent"
+                  _hover={totalAccounts > 1 ? {
+                    bg: "red.50",
+                    borderColor: "bauhaus.red",
+                  } : undefined}
+                  w="full"
+                  isDisabled={totalAccounts <= 1}
+                >
+                  Remove Account
+                </Button>
+              </Tooltip>
             </VStack>
           </VStack>
         </ModalBody>


### PR DESCRIPTION
## Summary
- Users could remove all accounts, causing the account dropdown to disappear. On reload, orphaned legacy storage data (`address`, `encryptedApiKey`) triggered migration logic that recreated a ghost "Bankr" account.
- Added a backend guard in `handleRemoveAccount` that rejects removal when only 1 account remains
- Added a UI guard that disables the "Remove Account" button with a tooltip when it's the last account

## Test plan
- [x] With multiple accounts: verify "Remove Account" button works normally
- [x] With a single account: verify "Remove Account" button is disabled and grayed out
- [x] With a single account: hover over the disabled button to see "Cannot remove the last account" tooltip
- [x] Remove accounts down to 1 and verify the button becomes disabled dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)