### PR TITLE
fix: Arc browser popup not opening (sidepanel regression)

### DIFF
--- a/apps/extension/src/chrome/sidepanelManager.ts
+++ b/apps/extension/src/chrome/sidepanelManager.ts
@@ -1,16 +1,19 @@
 /**
  * Side panel management utilities
  * Handles browser detection, sidepanel API support, and mode toggling
+ *
+ * KEY DESIGN: We never use openPanelOnActionClick (it suppresses the popup completely).
+ * Instead, we control behavior via chrome.action.setPopup():
+ * - Popup mode: setPopup({ popup: 'popup-init.html' }) → native popup opens
+ * - Sidepanel mode: setPopup({ popup: '' }) → action.onClicked fires → sidePanel.open() with fallback
  */
 
 /**
- * Checks if we're running in Arc browser
- * Arc has chrome.sidePanel but it doesn't work properly
+ * Checks if we're running in Arc browser (older versions with UA signal)
  * Note: In service worker context, we can't check CSS variables, so we use storage
  */
 export function isArcBrowser(): boolean {
   try {
-    // Arc browser identifies itself in the user agent
     return navigator.userAgent.includes("Arc/");
   } catch {
     return false;
@@ -18,13 +21,33 @@ export function isArcBrowser(): boolean {
 }
 
 /**
+ * Checks if this is a non-Chrome Chromium browser (Arc, Brave, Opera, etc.)
+ * These browsers expose chrome.sidePanel but it may not work properly.
+ * Arc's sidePanel API is a "perfect phantom" — sidePanel.open() resolves successfully
+ * and getContexts reports a SIDE_PANEL context, but nothing is rendered.
+ * Genuine Chrome always includes "Google Chrome" in userAgentData.brands.
+ */
+export function isNonChromeBrowser(): boolean {
+  try {
+    const uaData = (navigator as any).userAgentData;
+    if (!uaData?.brands) return false;
+    const hasGoogleChrome = uaData.brands.some(
+      (b: { brand: string }) => b.brand === "Google Chrome"
+    );
+    return !hasGoogleChrome;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks if the browser supports the sidePanel API
- * Note: Some browsers (like Arc) may have chrome.sidePanel defined but non-functional
+ * Only returns true on genuine Chrome — other Chromium browsers (Arc, Brave, etc.)
+ * may expose chrome.sidePanel but it silently fails to render.
  */
 export function isSidePanelSupported(): boolean {
   try {
-    // Arc browser has broken sidepanel support - skip entirely
-    if (isArcBrowser()) {
+    if (isArcBrowser() || isNonChromeBrowser()) {
       return false;
     }
     return typeof chrome !== "undefined" &&
@@ -37,20 +60,16 @@ export function isSidePanelSupported(): boolean {
 }
 
 /**
- * Tests if sidepanel actually works by attempting to set panel behavior
- * Returns true only if the API call succeeds
+ * Tests if sidepanel actually works by checking sidePanel.open availability
+ * Returns true only if the API appears functional
  */
 export async function testSidePanelWorks(): Promise<boolean> {
   try {
     if (!isSidePanelSupported()) {
       return false;
     }
-
-    // Try to set panel behavior - if this fails, the API is broken
-    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
-    return true;
-  } catch (error) {
-    console.warn("SidePanel API exists but is non-functional:", error);
+    return typeof chrome.sidePanel.open === "function";
+  } catch {
     return false;
   }
 }
@@ -62,10 +81,8 @@ export async function getSidePanelMode(): Promise<boolean> {
   if (!isSidePanelSupported()) {
     return false;
   }
-  // Check if we've previously determined sidepanel doesn't work (e.g., Arc browser)
   const { sidePanelMode, sidePanelVerified } = await chrome.storage.sync.get(["sidePanelMode", "sidePanelVerified"]);
 
-  // If we haven't verified yet, or verification found it doesn't work, return false
   if (sidePanelVerified === false) {
     return false;
   }
@@ -76,54 +93,79 @@ export async function getSidePanelMode(): Promise<boolean> {
 
 /**
  * Sets the sidepanel mode setting
- * Returns false if setting sidepanel behavior failed (browser doesn't support it properly)
+ * Uses chrome.action.setPopup to control behavior:
+ * - Sidepanel mode: popup = '' (action.onClicked fires, which calls sidePanel.open)
+ * - Popup mode: popup = 'popup-init.html' (native popup opens)
+ * Returns false if sidepanel mode cannot be enabled
  */
 export async function setSidePanelMode(enabled: boolean): Promise<boolean> {
+  // Block enabling on non-Chrome browsers (Arc, Brave, etc.) - sidepanel silently fails
+  if (enabled && isNonChromeBrowser()) {
+    return false;
+  }
+
   // Check if Arc browser first - sidepanel is broken there
   const { isArcBrowser: storedIsArc } = await chrome.storage.sync.get(["isArcBrowser"]);
   if (storedIsArc && enabled) {
-    // Can't enable sidepanel in Arc
     return false;
   }
 
   if (!isSidePanelSupported()) {
-    // No sidepanel support at all
     if (enabled) {
       return false;
     }
     await chrome.storage.sync.set({ sidePanelMode: false });
-    return true; // Successfully set to popup mode (the only option)
+    await chrome.action.setPopup({ popup: "popup-init.html" });
+    return true;
   }
 
   try {
     if (enabled) {
-      // Trying to enable sidepanel - test first
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
-      // If we get here, it worked
+      // Clear popup so action.onClicked fires → sidePanel.open() in background.ts
+      await chrome.action.setPopup({ popup: "" });
       await chrome.storage.sync.set({ sidePanelMode: true, sidePanelVerified: true });
       return true;
     } else {
-      // Disabling sidepanel (going to popup mode)
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+      // Restore native popup
+      await chrome.action.setPopup({ popup: "popup-init.html" });
       await chrome.storage.sync.set({ sidePanelMode: false });
       return true;
     }
   } catch (error) {
-    console.warn("Failed to set sidepanel behavior:", error);
-    // Mark sidepanel as not working for this browser
+    console.warn("Failed to set sidepanel mode:", error);
     await chrome.storage.sync.set({ sidePanelVerified: false, sidePanelMode: false });
+    await chrome.action.setPopup({ popup: "popup-init.html" });
     return false;
   }
 }
 
 /**
  * Initialize sidepanel behavior on startup
- * IMPORTANT: We default to popup mode and only enable sidepanel when explicitly requested by UI
- * This ensures Arc browser (where sidepanel is broken) works properly with popup
+ * IMPORTANT: Never use openPanelOnActionClick — it's an all-or-nothing setting that
+ * suppresses the popup completely. Instead, we control behavior via chrome.action.setPopup():
+ * - Popup mode: setPopup({ popup: 'popup-init.html' }) → native popup opens
+ * - Sidepanel mode: setPopup({ popup: '' }) → action.onClicked fires → sidePanel.open() with fallback
  */
 export async function initSidePanel(): Promise<void> {
   try {
-    // Check if we've stored that this is Arc browser (detected by UI via CSS variable)
+    // Always disable openPanelOnActionClick — we handle sidepanel opening manually
+    if (chrome.sidePanel?.setPanelBehavior) {
+      try {
+        await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+      } catch {
+        // Ignore errors - some browsers don't have this API
+      }
+    }
+
+    // Detect non-Chrome Chromium browsers (Arc, Brave, etc.) where sidePanel silently fails
+    if (isNonChromeBrowser()) {
+      // Persist the flag and force-disable sidepanel if it was previously enabled
+      await chrome.storage.sync.set({ sidePanelVerified: false, sidePanelMode: false });
+      await chrome.action.setPopup({ popup: "popup-init.html" });
+      return;
+    }
+
+    // Check stored flags
     const { isArcBrowser: storedIsArc, sidePanelMode, sidePanelVerified } = await chrome.storage.sync.get([
       "isArcBrowser",
       "sidePanelMode",
@@ -131,54 +173,29 @@ export async function initSidePanel(): Promise<void> {
     ]);
 
     if (storedIsArc) {
-      // Arc browser - sidepanel doesn't work, ensure popup mode
-      console.log("Arc browser detected, ensuring popup mode");
-      // Make absolutely sure sidepanel won't intercept clicks
-      if (chrome.sidePanel?.setPanelBehavior) {
-        try {
-          await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
-        } catch {
-          // Ignore errors
-        }
-      }
+      await chrome.action.setPopup({ popup: "popup-init.html" });
       return;
     }
 
-    // If sidepanel has been verified as not working, ensure popup mode
     if (sidePanelVerified === false) {
-      if (chrome.sidePanel?.setPanelBehavior) {
-        try {
-          await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
-        } catch {
-          // Ignore errors
-        }
-      }
+      await chrome.action.setPopup({ popup: "popup-init.html" });
       return;
     }
 
-    // Only enable sidepanel if it's explicitly been enabled by user AND verified to work
-    // This is the key change: we don't auto-enable sidepanel on first run
+    // Only enable sidepanel if explicitly enabled by user AND verified to work
     if (isSidePanelSupported() && sidePanelMode === true && sidePanelVerified === true) {
-      try {
-        await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
-      } catch (error) {
-        // If setting sidepanel fails, disable it
-        console.warn("Failed to enable sidepanel:", error);
-        await chrome.storage.sync.set({ sidePanelVerified: false, sidePanelMode: false });
-      }
+      // Clear popup so action.onClicked fires → sidePanel.open() in background.ts
+      await chrome.action.setPopup({ popup: "" });
     } else {
-      // Default: ensure popup mode (sidepanel won't intercept clicks)
-      if (chrome.sidePanel?.setPanelBehavior) {
-        try {
-          await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
-        } catch {
-          // Ignore errors - some browsers don't have this API
-        }
-      }
+      // Default: ensure popup mode
+      await chrome.action.setPopup({ popup: "popup-init.html" });
     }
   } catch (error) {
-    // If anything fails during sidepanel initialization, log and continue
-    // The extension will fall back to popup mode (which is the safe default)
     console.error("Error during sidepanel initialization:", error);
+    try {
+      await chrome.action.setPopup({ popup: "popup-init.html" });
+    } catch {
+      // Last resort - ignore
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: Arc's sidePanel API is a "perfect phantom" — `sidePanel.open()` resolves, `getContexts` reports a context, but nothing renders. Arc also removed its UA string and CSS variable detection signals.
- Replace `openPanelOnActionClick` (all-or-nothing, no fallback) with explicit `sidePanel.open()` via `action.onClicked` listener + `chrome.action.setPopup()` to control popup vs sidepanel mode
- Detect non-Chrome Chromium browsers (Arc, Brave, etc.) using `navigator.userAgentData.brands` — genuine Chrome always includes `"Google Chrome"`
- Add self-healing fallback: if `sidePanel.open()` fails or sidepanel doesn't actually appear, auto-disable sidepanel mode and open popup window
- On non-Chrome browsers, `initSidePanel()` force-disables sidepanel on every service worker startup

## Test plan
- [x] Chrome: sidepanel mode works (icon click opens sidepanel)
- [x] Chrome: toggling sidepanel on/off in Settings works correctly
- [x] Arc: first load auto-disables sidepanel, native popup opens on icon click
- [x] Transaction confirmation popup still works in both modes
- [x] `pnpm build:extension` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)