### PR TITLE
WIP: Local Ollama AI chat for PK/SP accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,10 @@ apps/extension/src/
 │   ├── authHandlers.ts      # Unlock, password change, vault key migration
 │   ├── sessionCache.ts      # Credential caching, auto-lock, session restore
 │   ├── txHandlers.ts        # Transaction/signature handling, account mgmt
-│   ├── chatHandlers.ts      # Bankr AI chat prompt handling
+│   ├── chatHandlers.ts      # Chat prompt routing (Bankr API or Ollama)
+│   ├── ollamaApi.ts         # Ollama HTTP client, settings, streaming
+│   ├── ollamaHandlers.ts    # Ollama tool execution loop with streaming
+│   ├── ollamaTools.ts       # Tool definitions, XML parser, executor
 │   ├── sidepanelManager.ts  # Sidepanel/popup mode, Arc browser detection
 │   ├── crypto.ts            # AES-256-GCM encryption for API keys
 │   ├── cryptoUtils.ts       # Shared crypto utilities (PBKDF2, base64)
@@ -205,6 +208,7 @@ When working on features, refer to these docs:
 | `_docs/APPS.md`                                          | Apps page data source, fetch script, adding chains        |
 | `_docs/SWAP.md`                                          | Swap page: 0x API integration, fees, slippage, UI         |
 | `_docs/COINS.md`                                         | Coins page: SSE streaming, indexer API, pagination        |
+| `_docs/OLLAMA.md`                                        | Local AI chat: Ollama setup, model, tools, streaming      |
 | `_docs/CALLDATA.md`                                      | Calldata decoder UI, param components, type routing       |
 | `_docs/ASSET_CHANGES_SIMULATION.md`                      | Tx simulation: state override injection, metadata retry   |
 | `_docs/ERC5792.md`                                       | ERC-5792 batch txs: message flow, ERC-7821 encoding, 7702 plan |

--- a/_docs/OLLAMA.md
+++ b/_docs/OLLAMA.md
@@ -1,0 +1,186 @@
+# Local AI Chat (Ollama Integration)
+
+## Overview
+
+PK and Seed Phrase accounts can chat with a local AI model via [Ollama](https://ollama.com), providing an AI assistant without any cloud dependency. Bankr API accounts continue to use the Bankr API chat.
+
+## Model
+
+- **Model**: [NaniDAO/nani-qwen-3.5-2B-gguf-q4km](https://huggingface.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km) (Q4_K_M quantization, 1.27 GB)
+- **Base**: Qwen3.5-2B, fine-tuned with LoRA on 2,029 examples covering 103 blockchain tools
+- **Tool calling format**: XML-based (`<tool_call><function=NAME><parameter=KEY>VALUE</parameter></function></tool_call>`)
+- **Think blocks**: Model outputs `<think>...</think>` reasoning blocks (hidden from user, shown as "Thinking..." status)
+- **Related repos**:
+  - [NaniDAO/nani-local](https://github.com/NaniDAO/nani-local) — Vite + React test app with Ollama
+  - [NaniDAO/agentek](https://github.com/NaniDAO/agentek) — Tool definitions (103 blockchain tools)
+
+## Setup
+
+```bash
+# 1. Install Ollama
+brew install ollama
+
+# 2. Pull the model
+ollama pull hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M
+ollama cp hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M nani
+
+# 3. Create with proper Modelfile (ChatML template + stop tokens)
+cat > /tmp/nani-Modelfile << 'EOF'
+FROM nani:latest
+
+PARAMETER temperature 0.7
+PARAMETER top_p 0.8
+PARAMETER top_k 20
+PARAMETER stop "<|im_start|>"
+PARAMETER stop "<|im_end|>"
+PARAMETER num_ctx 4096
+
+TEMPLATE """{{- if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{- range .Messages }}{{- if eq .Role "user" }}<|im_start|>user
+{{ .Content }}<|im_end|>
+{{ else if eq .Role "assistant" }}<|im_start|>assistant
+{{ .Content }}<|im_end|>
+{{ else if eq .Role "tool" }}<|im_start|>tool
+{{ .Content }}<|im_end|>
+{{ end }}{{- end }}<|im_start|>assistant
+"""
+
+SYSTEM """You are Nani, a crypto wallet assistant."""
+EOF
+
+ollama create nani -f /tmp/nani-Modelfile
+
+# 4. Start Ollama (MUST allow extension origin)
+OLLAMA_ORIGINS=* ollama serve
+```
+
+**Critical**: The `OLLAMA_ORIGINS=*` env var is required. Without it, Ollama rejects requests from the Chrome extension's `chrome-extension://` origin with a 403.
+
+**Critical**: The Modelfile with ChatML template is required. Without it, `ollama pull` creates the model with `TEMPLATE {{ .Prompt }}` which produces garbage output (no role markers, no stop tokens, next-word prediction loops).
+
+## Architecture
+
+```
+User prompt → useChat hook → chrome.runtime.sendMessage("submitChatPrompt")
+                                         ↓
+                              chatHandlers.ts (routes by account type)
+                                    ↓                    ↓
+                          Bankr API (bankr)    Ollama (PK/SP)
+                                                    ↓
+                                         ollamaHandlers.ts
+                                    ┌───────────────────────┐
+                                    │   Tool Execution Loop  │
+                                    │                        │
+                                    │  1. Stream response    │
+                                    │  2. Parse <tool_call>  │
+                                    │  3. Execute tool       │
+                                    │  4. Feed result back   │
+                                    │  5. Repeat (max 5x)    │
+                                    └───────────────────────┘
+                                                    ↓
+                              chatJobUpdate (streaming tokens)
+                              chatJobComplete (final message)
+                                                    ↓
+                                           UI renders response
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `chrome/ollamaApi.ts` | Ollama HTTP client: settings persistence (`ollamaSettings` in `chrome.storage.sync`), health check (`/api/tags`), chat (`/api/chat` with stream), model parameters (stop tokens, temperature, etc.) |
+| `chrome/ollamaTools.ts` | Tool definitions (system prompt builder), XML tool call parser, tool executor, think-tag stripper |
+| `chrome/ollamaHandlers.ts` | Multi-turn tool execution loop with streaming, abort controller for stop button |
+| `components/Settings/OllamaSettings.tsx` | Settings UI: enable toggle, URL/model config, test connection, setup guide |
+
+## Message Flow
+
+### Routing (chatHandlers.ts)
+
+`handleSubmitChatPrompt` checks the active account type:
+- `privateKey` or `seedPhrase` → routes to `handleOllamaChatPrompt` (if Ollama enabled in settings)
+- `bankr` or `impersonator` → existing Bankr API flow (unchanged)
+
+### Streaming
+
+Uses `stream: true` with the Ollama `/api/chat` endpoint. Tokens are parsed from newline-delimited JSON and sent to the UI via `chatJobUpdate` messages with a `streamContent` field. The `<think>` block is detected during streaming and hidden — user sees "Thinking..." status until the visible response begins.
+
+Updates are throttled to every 80ms to avoid flooding the UI.
+
+### Tool Execution Loop
+
+1. Stream full response from Ollama
+2. Parse for `<tool_call>` XML blocks
+3. If tool calls found:
+   - Send status update (e.g., "Checking balance...")
+   - Execute each tool
+   - Append assistant response + tool results to message history
+   - Stream next response (go to step 1)
+4. If no tool calls → final answer, save and notify UI
+5. Max 5 iterations to prevent infinite loops
+
+### Stop Button
+
+An `AbortController` is stored per conversation in `activeRequests` map. The UI sends `cancelOllamaChat` message → handler calls `controller.abort()` → fetch is cancelled → last streamed content is preserved as the final message.
+
+## Supported Tools (MVP)
+
+| Tool | Description | Implementation |
+|------|-------------|----------------|
+| `getBalance` | Native token balance | viem `client.getBalance()` |
+| `getBalanceOf` | ERC20 token balance | viem `client.readContract()` with `erc20Abi` |
+| `resolveENS` | Name → address (ENS, Basename, WNS, MegaName) | `lib/ensUtils.ts` `resolveNameToAddress()` |
+| `lookupENS` | Address → name (reverse resolution) | `lib/ensUtils.ts` `resolveAddressToName()` |
+| `getCryptoPrice` | Native token price in USD | `coingeckoService.ts` `fetchNativeCoinGeckoPrice()` |
+| `intentTransfer` | Prepare token transfer (user confirms via tx confirmation UI) | Builds tx, saves as `PendingTxRequest` — never auto-signs |
+
+## Settings
+
+Stored in `chrome.storage.sync` under key `ollamaSettings`:
+
+```typescript
+interface OllamaSettings {
+  enabled: boolean;    // default: false
+  baseUrl: string;     // default: "http://localhost:11434"
+  modelName: string;   // default: "nani"
+}
+```
+
+Settings UI: Settings → Local AI Chat
+
+## Chat Storage
+
+Conversations are stored in the shared `chatHistory` key (same as Bankr API chats). Each conversation has an optional `address` field tagging which wallet initiated it.
+
+- **Default view**: ChatList filters by active wallet address
+- **"All wallets" toggle**: Shows conversations from all addresses with address badges
+
+## Model Parameters (sent via API)
+
+```typescript
+{
+  temperature: 0.7,
+  top_p: 0.8,
+  top_k: 20,
+  num_ctx: 4096,
+  stop: ["<|im_start|>", "<|im_end|>"]
+}
+```
+
+These are also baked into the Modelfile, but sent in the API request as a safety net.
+
+## Known Limitations
+
+- **2B model**: May hallucinate tool names or pick wrong parameters; works best with the defined tool set
+- **No vision**: GGUF doesn't include the vision encoder
+- **Requires local Ollama**: User must install, configure, and run Ollama separately
+- **OLLAMA_ORIGINS**: Must be set to `*` for Chrome extension access
+- **Service worker lifecycle**: The `handleOllamaChatPrompt` promise is awaited (not fire-and-forget) to prevent Chrome from suspending the service worker during inference
+
+## Future Improvements
+
+- Additional tools: `intentSwap` (via 0x API), more DeFi interactions
+- Streaming think-block display (show reasoning in collapsed section)
+- Model selection UI (allow other Ollama models)
+- Auto-detect Ollama availability on extension startup

--- a/apps/extension/src/App.tsx
+++ b/apps/extension/src/App.tsx
@@ -1810,6 +1810,8 @@ function App() {
               onWalletLocked={() => {
                 setIsWalletUnlocked(false);
               }}
+              address={activeAccount?.address}
+              chainId={selectedChain?.chainId}
             />
           </Suspense>
         </Box>
@@ -2317,7 +2319,7 @@ function App() {
           </HStack>
           <Spacer />
           <HStack spacing={1}>
-            {activeAccount?.type === "bankr" && (
+            {(activeAccount?.type === "bankr" || activeAccount?.type === "privateKey" || activeAccount?.type === "seedPhrase") && (
               <Tooltip label="Chat History" placement="bottom">
                 <IconButton
                   aria-label="Chat History"
@@ -3192,8 +3194,8 @@ function App() {
           </VStack>
         </Container>
 
-        {/* Sticky Footer - only show for Bankr accounts */}
-        {activeAccount?.type === "bankr" && (
+        {/* Sticky Footer - show for Bankr, PK, and SP accounts */}
+        {(activeAccount?.type === "bankr" || activeAccount?.type === "privateKey" || activeAccount?.type === "seedPhrase") && (
           <Box
             position="sticky"
             bottom={0}
@@ -3267,7 +3269,7 @@ function App() {
                 }}
                 leftIcon={<ChatIcon />}
               >
-                Chat with Bankr
+                {activeAccount?.type === "bankr" ? "Chat with Bankr" : "Chat with Nani"}
               </Button>
             </Box>
           </Box>

--- a/apps/extension/src/chrome/background.ts
+++ b/apps/extension/src/chrome/background.ts
@@ -2030,6 +2030,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         message.conversationId,
         message.messageId,
         message.prompt,
+        message.chainId,
       ).then((result) => {
         sendResponse(result);
       });
@@ -2051,7 +2052,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     case "createChatConversation": {
-      createConversation(message.title).then((conversation) => {
+      createConversation(message.title, message.address).then((conversation) => {
         sendResponse(conversation);
       });
       return true;
@@ -2080,6 +2081,40 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         message.updates,
       ).then((conversation) => {
         sendResponse(conversation);
+      });
+      return true;
+    }
+
+    // Ollama settings handlers
+    case "getOllamaSettings": {
+      import("./ollamaApi").then(({ getOllamaSettings }) => {
+        getOllamaSettings().then((settings) => sendResponse(settings));
+      });
+      return true;
+    }
+
+    case "saveOllamaSettings": {
+      import("./ollamaApi").then(({ saveOllamaSettings }) => {
+        saveOllamaSettings(message.settings).then(() =>
+          sendResponse({ success: true })
+        );
+      });
+      return true;
+    }
+
+    case "checkOllamaAvailability": {
+      import("./ollamaApi").then(({ checkOllamaAvailability }) => {
+        checkOllamaAvailability(message.baseUrl).then((result) =>
+          sendResponse(result)
+        );
+      });
+      return true;
+    }
+
+    case "cancelOllamaChat": {
+      import("./ollamaHandlers").then(({ cancelOllamaChat }) => {
+        const cancelled = cancelOllamaChat(message.conversationId);
+        sendResponse({ success: cancelled });
       });
       return true;
     }

--- a/apps/extension/src/chrome/chatHandlers.ts
+++ b/apps/extension/src/chrome/chatHandlers.ts
@@ -1,6 +1,6 @@
 /**
- * Chat prompt handlers for Bankr AI chat
- * Manages chat submission and background polling
+ * Chat prompt handlers for Bankr AI chat and local Ollama chat
+ * Routes to Bankr API (bankr accounts) or Ollama (PK/SP accounts)
  */
 
 import {
@@ -18,15 +18,54 @@ import {
   tryRestoreSession,
 } from "./sessionCache";
 import { handleUnlockWallet } from "./authHandlers";
+import { getActiveAccount } from "./accountStorage";
+import { handleOllamaChatPrompt } from "./ollamaHandlers";
+import { getOllamaSettings } from "./ollamaApi";
 
 /**
- * Handles chat prompt submission - sends to Bankr API and polls for response
+ * Handles chat prompt submission - routes to Ollama for PK/SP or Bankr API for bankr accounts
  */
 export async function handleSubmitChatPrompt(
   conversationId: string,
   messageId: string,
-  prompt: string
+  prompt: string,
+  chainId?: number
 ): Promise<{ success: boolean; error?: string }> {
+  // Check account type to route chat
+  const activeAccount = await getActiveAccount();
+
+  if (
+    activeAccount &&
+    (activeAccount.type === "privateKey" ||
+      activeAccount.type === "seedPhrase")
+  ) {
+    // Route to Ollama handler for PK/SP accounts
+    const ollamaSettings = await getOllamaSettings();
+    if (!ollamaSettings.enabled) {
+      chrome.runtime
+        .sendMessage({
+          type: "chatJobComplete",
+          conversationId,
+          messageId,
+          error:
+            "Local AI chat is not configured. Enable Ollama in Settings → Local AI Chat.",
+        })
+        .catch(() => {});
+      return {
+        success: false,
+        error: "Local AI chat is not configured",
+      };
+    }
+    return handleOllamaChatPrompt(
+      conversationId,
+      messageId,
+      prompt,
+      activeAccount.address,
+      chainId || 1
+    );
+  }
+
+  // Bankr API flow for bankr/impersonator accounts
   // Get cached API key
   let apiKey = getCachedApiKey();
 

--- a/apps/extension/src/chrome/chatStorage.ts
+++ b/apps/extension/src/chrome/chatStorage.ts
@@ -20,6 +20,7 @@ export interface Conversation {
   createdAt: number;
   updatedAt: number;
   favorite?: boolean;
+  address?: string; // wallet address that initiated this conversation
 }
 
 const STORAGE_KEY = "chatHistory";
@@ -34,6 +35,14 @@ export async function getConversations(): Promise<Conversation[]> {
     chatHistory?: Conversation[];
   };
   return chatHistory || [];
+}
+
+/**
+ * Get conversations filtered by address (case-insensitive)
+ */
+export async function getConversationsForAddress(address: string): Promise<Conversation[]> {
+  const all = await getConversations();
+  return all.filter((c) => c.address?.toLowerCase() === address.toLowerCase());
 }
 
 /**
@@ -81,7 +90,8 @@ export async function saveConversation(conversation: Conversation): Promise<void
  * Create a new conversation
  */
 export async function createConversation(
-  title?: string
+  title?: string,
+  address?: string
 ): Promise<Conversation> {
   const now = Date.now();
   const conversation: Conversation = {
@@ -90,6 +100,7 @@ export async function createConversation(
     messages: [],
     createdAt: now,
     updatedAt: now,
+    ...(address ? { address: address.toLowerCase() } : {}),
   };
 
   await saveConversation(conversation);

--- a/apps/extension/src/chrome/ollamaApi.ts
+++ b/apps/extension/src/chrome/ollamaApi.ts
@@ -1,0 +1,192 @@
+/**
+ * Ollama API client for local AI chat
+ * Handles settings persistence, health checks, and chat completions
+ */
+
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OLLAMA_MODEL,
+} from "@/constants/externalUrls";
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+const OLLAMA_SETTINGS_KEY = "ollamaSettings";
+
+export interface OllamaSettings {
+  enabled: boolean;
+  baseUrl: string;
+  modelName: string;
+}
+
+const DEFAULT_SETTINGS: OllamaSettings = {
+  enabled: false,
+  baseUrl: DEFAULT_OLLAMA_BASE_URL,
+  modelName: DEFAULT_OLLAMA_MODEL,
+};
+
+export async function getOllamaSettings(): Promise<OllamaSettings> {
+  const result = await chrome.storage.sync.get(OLLAMA_SETTINGS_KEY);
+  return { ...DEFAULT_SETTINGS, ...result[OLLAMA_SETTINGS_KEY] };
+}
+
+export async function saveOllamaSettings(
+  settings: Partial<OllamaSettings>
+): Promise<void> {
+  const current = await getOllamaSettings();
+  await chrome.storage.sync.set({
+    [OLLAMA_SETTINGS_KEY]: { ...current, ...settings },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Health Check
+// ---------------------------------------------------------------------------
+
+export async function checkOllamaAvailability(
+  baseUrl: string
+): Promise<{ available: boolean; models: string[] }> {
+  try {
+    const response = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (response.status === 403) {
+      return { available: false, models: [], error: "Ollama blocked the request. Restart with: OLLAMA_ORIGINS=* ollama serve" } as any;
+    }
+    if (!response.ok) {
+      return { available: false, models: [] };
+    }
+    const data = (await response.json()) as {
+      models?: Array<{ name: string }>;
+    };
+    const models = (data.models || []).map((m) => m.name);
+    return { available: true, models };
+  } catch {
+    return { available: false, models: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chat
+// ---------------------------------------------------------------------------
+
+export interface OllamaMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+}
+
+export interface OllamaChatResponse {
+  message: { role: string; content: string };
+  done: boolean;
+}
+
+// Model parameters from the nani Modelfile
+const NANI_MODEL_OPTIONS = {
+  temperature: 0.7,
+  top_p: 0.8,
+  top_k: 20,
+  num_ctx: 4096,
+  stop: ["<|im_start|>", "<|im_end|>"],
+};
+
+export async function ollamaChat(
+  baseUrl: string,
+  model: string,
+  messages: OllamaMessage[],
+  signal?: AbortSignal
+): Promise<OllamaChatResponse> {
+  const response = await fetch(`${baseUrl}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages, stream: false, options: NANI_MODEL_OPTIONS }),
+    signal,
+  });
+
+  handleOllamaError(response, model);
+
+  return response.json();
+}
+
+/**
+ * Streaming chat — calls onToken for each token, returns full content when done.
+ * Automatically hides <think>...</think> blocks from the streamed display.
+ */
+export async function ollamaChatStream(
+  baseUrl: string,
+  model: string,
+  messages: OllamaMessage[],
+  onToken: (displayContent: string) => void,
+  signal?: AbortSignal
+): Promise<string> {
+  const response = await fetch(`${baseUrl}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages, stream: true, options: NANI_MODEL_OPTIONS }),
+    signal,
+  });
+
+  handleOllamaError(response, model);
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let fullContent = "";
+  let insideThink = false;
+  let displayContent = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    const chunk = decoder.decode(value, { stream: true });
+    // Each line is a JSON object
+    for (const line of chunk.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const data = JSON.parse(line);
+        if (data.message?.content) {
+          const token = data.message.content;
+          fullContent += token;
+
+          // Track <think> blocks — hide from display
+          if (fullContent.includes("<think>") && !fullContent.includes("</think>")) {
+            insideThink = true;
+          }
+          if (insideThink && fullContent.includes("</think>")) {
+            insideThink = false;
+            // Rebuild display content without think block
+            displayContent = fullContent
+              .replace(/<think>[\s\S]*?<\/think>/g, "")
+              .trim();
+            onToken(displayContent);
+            continue;
+          }
+
+          if (!insideThink) {
+            displayContent += token;
+            onToken(displayContent.trim());
+          }
+        }
+      } catch {
+        // Skip malformed JSON lines
+      }
+    }
+  }
+
+  return fullContent;
+}
+
+function handleOllamaError(response: Response, model: string): void {
+  if (response.ok) return;
+  if (response.status === 404) {
+    throw new Error(
+      `Model '${model}' not found. Run \`ollama pull ${model}\` to download it.`
+    );
+  }
+  if (response.status === 403) {
+    throw new Error(
+      "Ollama blocked the request (403 Forbidden). Restart Ollama with: OLLAMA_ORIGINS=* ollama serve"
+    );
+  }
+  throw new Error(`Ollama API error (${response.status})`);
+}

--- a/apps/extension/src/chrome/ollamaHandlers.ts
+++ b/apps/extension/src/chrome/ollamaHandlers.ts
@@ -1,0 +1,292 @@
+/**
+ * Ollama chat handler for PK/SP accounts.
+ * Implements a multi-turn tool execution loop with streaming:
+ *   prompt → stream response → parse tool calls → execute → feed result back → repeat
+ */
+
+import {
+  getOllamaSettings,
+  checkOllamaAvailability,
+  ollamaChatStream,
+  ollamaChat,
+  type OllamaMessage,
+} from "./ollamaApi";
+import {
+  getConversation,
+  updateMessageInConversation,
+} from "./chatStorage";
+import {
+  buildSystemPrompt,
+  parseToolCalls,
+  cleanDisplayContent,
+  toolStatusMessage,
+  executeTool,
+  type ToolContext,
+} from "./ollamaTools";
+
+const MAX_TOOL_ITERATIONS = 5;
+// Throttle stream updates to avoid flooding the UI
+const STREAM_UPDATE_INTERVAL_MS = 80;
+
+// Active abort controllers keyed by conversationId
+const activeRequests = new Map<string, AbortController>();
+
+/**
+ * Cancel an active Ollama chat request.
+ */
+export function cancelOllamaChat(conversationId: string): boolean {
+  const controller = activeRequests.get(conversationId);
+  if (controller) {
+    controller.abort();
+    activeRequests.delete(conversationId);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Handle a chat prompt via local Ollama model with tool execution loop.
+ * Awaits processing to keep the service worker alive during the Ollama request.
+ */
+export async function handleOllamaChatPrompt(
+  conversationId: string,
+  messageId: string,
+  prompt: string,
+  accountAddress: string,
+  chainId: number
+): Promise<{ success: boolean; error?: string }> {
+  await processOllamaPromptInBackground(
+    conversationId,
+    messageId,
+    prompt,
+    accountAddress,
+    chainId
+  );
+
+  return { success: true };
+}
+
+async function processOllamaPromptInBackground(
+  conversationId: string,
+  messageId: string,
+  prompt: string,
+  accountAddress: string,
+  chainId: number
+): Promise<void> {
+  // Create abort controller for this request
+  const abortController = new AbortController();
+  activeRequests.set(conversationId, abortController);
+  const { signal } = abortController;
+
+  // Track last streamed display content (accessible in catch for abort)
+  let lastStreamedDisplay = "";
+
+  try {
+    // 1. Load settings and validate
+    const settings = await getOllamaSettings();
+    const { available } = await checkOllamaAvailability(settings.baseUrl);
+    if (!available) {
+      await failWithError(
+        conversationId,
+        messageId,
+        "Ollama is not running. Start it with `ollama serve` and ensure the nani model is loaded (`ollama pull nani`)."
+      );
+      return;
+    }
+
+    // 2. Send initial status update
+    sendStatusUpdate(conversationId, messageId, "Thinking...");
+
+    // 3. Build conversation history
+    const messages: OllamaMessage[] = [];
+
+    messages.push({
+      role: "system",
+      content: buildSystemPrompt(accountAddress, chainId),
+    });
+
+    const conversation = await getConversation(conversationId);
+    if (conversation) {
+      for (const msg of conversation.messages) {
+        if (msg.id === messageId) continue;
+        if (msg.status === "pending" || msg.status === "error") continue;
+        if (!msg.content || msg.content.trim() === "") continue;
+
+        messages.push({
+          role: msg.role === "user" ? "user" : "assistant",
+          content: msg.content,
+        });
+      }
+
+      if (
+        messages.length > 1 &&
+        messages[messages.length - 1].role === "user"
+      ) {
+        messages.pop();
+      }
+    }
+
+    messages.push({ role: "user", content: prompt });
+
+    // 4. Tool execution loop with streaming
+    const toolCtx: ToolContext = {
+      address: accountAddress,
+      chainId,
+    };
+
+    let finalContent = "";
+    let lastStreamUpdate = 0;
+
+    for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+      // Stream the response — tokens appear in the UI as they arrive
+      const fullContent = await ollamaChatStream(
+        settings.baseUrl,
+        settings.modelName,
+        messages,
+        (displayContent) => {
+          lastStreamedDisplay = displayContent;
+          const now = Date.now();
+          if (now - lastStreamUpdate >= STREAM_UPDATE_INTERVAL_MS) {
+            lastStreamUpdate = now;
+            sendStreamContent(conversationId, messageId, displayContent);
+          }
+        },
+        signal
+      );
+
+      const toolCalls = parseToolCalls(fullContent);
+
+      if (toolCalls.length === 0) {
+        finalContent = cleanDisplayContent(fullContent);
+        // Send final streamed content
+        sendStreamContent(conversationId, messageId, finalContent);
+        break;
+      }
+
+      // Execute tool calls (switch back to status messages during tool execution)
+      const toolResults: string[] = [];
+      for (const call of toolCalls) {
+        sendStatusUpdate(
+          conversationId,
+          messageId,
+          toolStatusMessage(call.functionName)
+        );
+
+        const result = await executeTool(call, toolCtx);
+        toolResults.push(`${call.functionName}: ${result}`);
+      }
+
+      messages.push({ role: "assistant", content: fullContent });
+      messages.push({ role: "tool", content: toolResults.join("\n") });
+
+      // Reset for next iteration
+      lastStreamUpdate = 0;
+
+      // If this is the last iteration, force a final response
+      if (i === MAX_TOOL_ITERATIONS - 1) {
+        sendStatusUpdate(conversationId, messageId, "Generating response...");
+        const lastContent = await ollamaChatStream(
+          settings.baseUrl,
+          settings.modelName,
+          messages,
+          (displayContent) => {
+            lastStreamedDisplay = displayContent;
+            const now = Date.now();
+            if (now - lastStreamUpdate >= STREAM_UPDATE_INTERVAL_MS) {
+              lastStreamUpdate = now;
+              sendStreamContent(conversationId, messageId, displayContent);
+            }
+          },
+          signal
+        );
+        finalContent = cleanDisplayContent(lastContent);
+        sendStreamContent(conversationId, messageId, finalContent);
+      }
+    }
+
+    // 5. Update message in storage and notify UI
+    await updateMessageInConversation(conversationId, messageId, {
+      content: finalContent || "No response generated.",
+      status: "complete",
+    });
+
+    chrome.runtime.sendMessage({
+      type: "chatJobComplete",
+      conversationId,
+      messageId,
+      content: finalContent || "No response generated.",
+    }).catch(() => {});
+  } catch (error) {
+    // Handle abort gracefully — keep whatever was streamed so far
+    if (error instanceof DOMException && error.name === "AbortError") {
+      const keptContent = lastStreamedDisplay || "Generation stopped.";
+      await updateMessageInConversation(conversationId, messageId, {
+        content: keptContent,
+        status: "complete",
+      });
+      chrome.runtime.sendMessage({
+        type: "chatJobComplete",
+        conversationId,
+        messageId,
+        content: keptContent,
+      }).catch(() => {});
+      return;
+    }
+
+    console.error("[Ollama] Chat error:", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    await failWithError(conversationId, messageId, errorMessage);
+  } finally {
+    activeRequests.delete(conversationId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sendStatusUpdate(
+  conversationId: string,
+  messageId: string,
+  message: string
+): void {
+  chrome.runtime.sendMessage({
+    type: "chatJobUpdate",
+    conversationId,
+    messageId,
+    statusUpdates: [{ message, timestamp: new Date().toISOString() }],
+  }).catch(() => {});
+}
+
+function sendStreamContent(
+  conversationId: string,
+  messageId: string,
+  content: string
+): void {
+  chrome.runtime.sendMessage({
+    type: "chatJobUpdate",
+    conversationId,
+    messageId,
+    streamContent: content,
+  }).catch(() => {});
+}
+
+async function failWithError(
+  conversationId: string,
+  messageId: string,
+  errorMessage: string
+): Promise<void> {
+  await updateMessageInConversation(conversationId, messageId, {
+    content: errorMessage,
+    status: "error",
+  });
+
+  chrome.runtime.sendMessage({
+    type: "chatJobComplete",
+    conversationId,
+    messageId,
+    content: errorMessage,
+    error: errorMessage,
+  }).catch(() => {});
+}

--- a/apps/extension/src/chrome/ollamaTools.ts
+++ b/apps/extension/src/chrome/ollamaTools.ts
@@ -1,0 +1,368 @@
+/**
+ * Tool definitions, parsing, and execution for local Ollama AI chat.
+ * Implements the tools the nani-qwen model was trained on.
+ */
+
+import {
+  createPublicClient,
+  http,
+  formatUnits,
+  erc20Abi,
+  parseUnits,
+  encodeFunctionData,
+  type Address,
+  type PublicClient,
+} from "viem";
+import { getStoredRpcUrl } from "@/lib/chains";
+import { resolveNameToAddress, resolveAddressToName } from "@/lib/ensUtils";
+import { fetchNativeCoinGeckoPrice } from "@/chrome/coingeckoService";
+import { savePendingTxRequest } from "@/chrome/pendingTxStorage";
+import { CHAIN_NAMES } from "@/constants/chainRegistry";
+import { CHAIN_REGISTRY } from "@/constants/chainRegistry";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolCall {
+  functionName: string;
+  parameters: Record<string, string>;
+}
+
+export interface ToolContext {
+  address: string;
+  chainId: number;
+}
+
+// ---------------------------------------------------------------------------
+// Viem client cache (matches onchainBalances.ts pattern)
+// ---------------------------------------------------------------------------
+
+const RPC_TIMEOUT = 8_000;
+const clientCache = new Map<number, { rpcUrl: string; client: PublicClient }>();
+
+async function getClient(chainId: number): Promise<PublicClient | null> {
+  const rpcUrl = await getStoredRpcUrl(chainId);
+  if (!rpcUrl) return null;
+
+  const cached = clientCache.get(chainId);
+  if (cached && cached.rpcUrl === rpcUrl) return cached.client;
+
+  const client = createPublicClient({
+    transport: http(rpcUrl, { timeout: RPC_TIMEOUT, retryCount: 0 }),
+  });
+  clientCache.set(chainId, { rpcUrl, client });
+  return client;
+}
+
+// ---------------------------------------------------------------------------
+// System prompt builder
+// ---------------------------------------------------------------------------
+
+export function buildSystemPrompt(address: string, chainId: number): string {
+  const chainName = CHAIN_NAMES[chainId] || `Chain ${chainId}`;
+  const chainEntry = CHAIN_REGISTRY.find((c) => c.chainId === chainId);
+  const nativeSymbol = chainEntry?.nativeCurrency.symbol || "ETH";
+
+  return `# Tools
+
+You have access to the following functions:
+
+<tools>
+{"type":"function","function":{"name":"getBalance","description":"Get the native token (${nativeSymbol}) balance for an address on a specific chain","parameters":{"type":"object","properties":{"address":{"type":"string","description":"The wallet address (0x...)"},"chainId":{"type":"number","description":"Chain ID (default: ${chainId})"}},"required":["address"]}}}
+{"type":"function","function":{"name":"getBalanceOf","description":"Get an ERC20 token balance for an address","parameters":{"type":"object","properties":{"address":{"type":"string","description":"The wallet address (0x...)"},"tokenAddress":{"type":"string","description":"The ERC20 token contract address (0x...)"},"chainId":{"type":"number","description":"Chain ID (default: ${chainId})"}},"required":["address","tokenAddress"]}}}
+{"type":"function","function":{"name":"resolveENS","description":"Resolves an ENS name (or Basename, WNS, MegaName) to an Ethereum address","parameters":{"type":"object","properties":{"name":{"type":"string","description":"The name to resolve (e.g. vitalik.eth, jesse.base.eth, nani.wei)"}},"required":["name"]}}}
+{"type":"function","function":{"name":"lookupENS","description":"Reverse-resolves an Ethereum address to its primary name (ENS, Basename, WNS, or MegaName)","parameters":{"type":"object","properties":{"address":{"type":"string","description":"The wallet address (0x...)"}},"required":["address"]}}}
+{"type":"function","function":{"name":"getCryptoPrice","description":"Get the current price of the chain's native token in USD","parameters":{"type":"object","properties":{"chainId":{"type":"number","description":"Chain ID (default: ${chainId})"}},"required":[]}}}
+{"type":"function","function":{"name":"intentTransfer","description":"Send native tokens or ERC20 tokens to an address. The user will be asked to confirm the transaction.","parameters":{"type":"object","properties":{"to":{"type":"string","description":"Recipient address (0x...) or ENS name"},"amount":{"type":"string","description":"Amount to send (human-readable, e.g. '0.1')"},"tokenAddress":{"type":"string","description":"ERC20 token contract address. Omit for native token transfer."},"chainId":{"type":"number","description":"Chain ID (default: ${chainId})"}},"required":["to","amount"]}}}
+</tools>
+
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<tool_call>
+<function=example_function_name>
+<parameter=example_parameter_1>value_1</parameter>
+</function>
+</tool_call>
+
+<IMPORTANT>
+Reminder:
+- Function calls MUST follow the specified format
+- Required parameters MUST be specified
+- You may provide optional reasoning BEFORE the function call, but NOT after
+- If there is no function call available, answer the question like normal
+</IMPORTANT>
+
+You are Nani, a crypto wallet assistant. You help the user manage their wallet and interact with blockchain networks.
+
+The user's wallet address is: ${address}
+Current chain: ${chainName} (Chain ID: ${chainId})
+Native token: ${nativeSymbol}
+
+When the user asks about their balance without specifying an address, use their wallet address.
+When the user asks about a chain without specifying, use the current chain.`;
+}
+
+// ---------------------------------------------------------------------------
+// Tool call parser
+// ---------------------------------------------------------------------------
+
+const TOOL_CALL_REGEX =
+  /<tool_call>\s*<function=(\w+)>([\s\S]*?)<\/function>\s*(?:<\/tool_call>)?/g;
+const PARAM_REGEX = /<parameter=(\w+)>([\s\S]*?)<\/parameter>/g;
+
+export function parseToolCalls(content: string): ToolCall[] {
+  const calls: ToolCall[] = [];
+  let match: RegExpExecArray | null;
+
+  TOOL_CALL_REGEX.lastIndex = 0;
+  while ((match = TOOL_CALL_REGEX.exec(content)) !== null) {
+    const functionName = match[1];
+    const paramsBlock = match[2];
+    const parameters: Record<string, string> = {};
+
+    let paramMatch: RegExpExecArray | null;
+    PARAM_REGEX.lastIndex = 0;
+    while ((paramMatch = PARAM_REGEX.exec(paramsBlock)) !== null) {
+      parameters[paramMatch[1]] = paramMatch[2].trim();
+    }
+
+    calls.push({ functionName, parameters });
+  }
+
+  return calls;
+}
+
+// ---------------------------------------------------------------------------
+// Think tag stripper
+// ---------------------------------------------------------------------------
+
+export function stripThinkTags(content: string): string {
+  return content.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+}
+
+// Also strip any remaining tool_call XML that wasn't caught
+export function cleanDisplayContent(content: string): string {
+  let cleaned = stripThinkTags(content);
+  cleaned = cleaned
+    .replace(/<tool_call>[\s\S]*?(?:<\/tool_call>|$)/g, "")
+    .trim();
+  return cleaned || content.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Status message helper
+// ---------------------------------------------------------------------------
+
+const STATUS_MESSAGES: Record<string, string> = {
+  getBalance: "Checking balance...",
+  getBalanceOf: "Checking token balance...",
+  resolveENS: "Resolving name...",
+  lookupENS: "Looking up address name...",
+  getCryptoPrice: "Fetching price...",
+  intentTransfer: "Preparing transfer...",
+};
+
+export function toolStatusMessage(functionName: string): string {
+  return STATUS_MESSAGES[functionName] || `Running ${functionName}...`;
+}
+
+// ---------------------------------------------------------------------------
+// Tool executor
+// ---------------------------------------------------------------------------
+
+export async function executeTool(
+  call: ToolCall,
+  ctx: ToolContext
+): Promise<string> {
+  try {
+    switch (call.functionName) {
+      case "getBalance":
+        return await toolGetBalance(call.parameters, ctx);
+      case "getBalanceOf":
+        return await toolGetBalanceOf(call.parameters, ctx);
+      case "resolveENS":
+        return await toolResolveENS(call.parameters);
+      case "lookupENS":
+        return await toolLookupENS(call.parameters);
+      case "getCryptoPrice":
+        return await toolGetCryptoPrice(call.parameters, ctx);
+      case "intentTransfer":
+        return await toolIntentTransfer(call.parameters, ctx);
+      default:
+        return `Unknown tool: ${call.functionName}`;
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return `Error executing ${call.functionName}: ${msg}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
+
+async function toolGetBalance(
+  params: Record<string, string>,
+  ctx: ToolContext
+): Promise<string> {
+  const address = (params.address || ctx.address) as Address;
+  const chainId = params.chainId ? Number(params.chainId) : ctx.chainId;
+  const chainEntry = CHAIN_REGISTRY.find((c) => c.chainId === chainId);
+  const symbol = chainEntry?.nativeCurrency.symbol || "ETH";
+  const decimals = chainEntry?.nativeCurrency.decimals || 18;
+
+  const client = await getClient(chainId);
+  if (!client) return `No RPC configured for chain ${chainId}`;
+
+  const balance = await client.getBalance({ address });
+  const formatted = formatUnits(balance, decimals);
+  return `${formatted} ${symbol}`;
+}
+
+async function toolGetBalanceOf(
+  params: Record<string, string>,
+  ctx: ToolContext
+): Promise<string> {
+  const address = (params.address || ctx.address) as Address;
+  const tokenAddress = params.tokenAddress as Address;
+  const chainId = params.chainId ? Number(params.chainId) : ctx.chainId;
+
+  if (!tokenAddress) return "tokenAddress is required";
+
+  const client = await getClient(chainId);
+  if (!client) return `No RPC configured for chain ${chainId}`;
+
+  const [balance, decimals, symbol] = await Promise.all([
+    client.readContract({
+      address: tokenAddress,
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [address],
+    }),
+    client.readContract({
+      address: tokenAddress,
+      abi: erc20Abi,
+      functionName: "decimals",
+    }),
+    client.readContract({
+      address: tokenAddress,
+      abi: erc20Abi,
+      functionName: "symbol",
+    }),
+  ]);
+
+  const formatted = formatUnits(balance, decimals);
+  return `${formatted} ${symbol}`;
+}
+
+async function toolResolveENS(
+  params: Record<string, string>
+): Promise<string> {
+  const name = params.name;
+  if (!name) return "name parameter is required";
+
+  const address = await resolveNameToAddress(name);
+  if (!address) return `Could not resolve "${name}" to an address`;
+  return address;
+}
+
+async function toolLookupENS(
+  params: Record<string, string>
+): Promise<string> {
+  const address = params.address;
+  if (!address) return "address parameter is required";
+
+  const name = await resolveAddressToName(address);
+  if (!name) return `No name found for ${address}`;
+  return name;
+}
+
+async function toolGetCryptoPrice(
+  params: Record<string, string>,
+  ctx: ToolContext
+): Promise<string> {
+  const chainId = params.chainId ? Number(params.chainId) : ctx.chainId;
+  const chainEntry = CHAIN_REGISTRY.find((c) => c.chainId === chainId);
+  const symbol = chainEntry?.nativeCurrency.symbol || "ETH";
+
+  const price = await fetchNativeCoinGeckoPrice(chainId);
+  if (price === null) return `Could not fetch price for ${symbol}`;
+  return `$${price.toFixed(2)} USD per ${symbol}`;
+}
+
+async function toolIntentTransfer(
+  params: Record<string, string>,
+  ctx: ToolContext
+): Promise<string> {
+  let to = params.to;
+  const amount = params.amount;
+  const tokenAddress = params.tokenAddress;
+  const chainId = params.chainId ? Number(params.chainId) : ctx.chainId;
+
+  if (!to || !amount) return "to and amount parameters are required";
+
+  // Resolve ENS name if needed
+  if (!to.startsWith("0x")) {
+    const resolved = await resolveNameToAddress(to);
+    if (!resolved) return `Could not resolve "${to}" to an address`;
+    to = resolved;
+  }
+
+  const chainEntry = CHAIN_REGISTRY.find((c) => c.chainId === chainId);
+  const chainName = chainEntry?.name || `Chain ${chainId}`;
+
+  if (tokenAddress) {
+    // ERC20 transfer
+    const client = await getClient(chainId);
+    if (!client) return `No RPC configured for chain ${chainId}`;
+
+    const decimals = await client.readContract({
+      address: tokenAddress as Address,
+      abi: erc20Abi,
+      functionName: "decimals",
+    });
+
+    const parsedAmount = parseUnits(amount, decimals);
+    const data = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [to as Address, parsedAmount],
+    });
+
+    await savePendingTxRequest({
+      id: crypto.randomUUID(),
+      tx: {
+        from: ctx.address,
+        to: tokenAddress,
+        data,
+        value: "0x0",
+        chainId,
+      },
+      origin: "Nani AI Chat",
+      favicon: null,
+      chainName,
+      timestamp: Date.now(),
+    });
+  } else {
+    // Native token transfer
+    const decimals = chainEntry?.nativeCurrency.decimals || 18;
+    const parsedAmount = parseUnits(amount, decimals);
+
+    await savePendingTxRequest({
+      id: crypto.randomUUID(),
+      tx: {
+        from: ctx.address,
+        to,
+        value: `0x${parsedAmount.toString(16)}`,
+        chainId,
+      },
+      origin: "Nani AI Chat",
+      favicon: null,
+      chainName,
+      timestamp: Date.now(),
+    });
+  }
+
+  return `Transfer of ${amount} ${tokenAddress ? "tokens" : chainEntry?.nativeCurrency.symbol || "ETH"} to ${to} has been prepared. Please confirm the transaction in your wallet.`;
+}

--- a/apps/extension/src/components/Chat/ChatInput.tsx
+++ b/apps/extension/src/components/Chat/ChatInput.tsx
@@ -1,16 +1,18 @@
 import { useState, KeyboardEvent } from "react";
 import { HStack, Input, IconButton, Box } from "@chakra-ui/react";
-import { ArrowForwardIcon } from "@chakra-ui/icons";
+import { ArrowForwardIcon, SmallCloseIcon } from "@chakra-ui/icons";
 
 interface ChatInputProps {
   onSend: (message: string) => void;
   isLoading: boolean;
+  onCancel?: () => void;
   placeholder?: string;
 }
 
 export function ChatInput({
   onSend,
   isLoading,
+  onCancel,
   placeholder = "Ask Bankr...",
 }: ChatInputProps) {
   const [input, setInput] = useState("");
@@ -61,29 +63,49 @@ export function ChatInput({
           fontWeight="500"
           fontSize="sm"
         />
-        <IconButton
-          aria-label="Send message"
-          icon={<ArrowForwardIcon />}
-          onClick={handleSend}
-          isDisabled={!input.trim() || isLoading}
-          bg="bauhaus.blue"
-          color="bauhaus.white"
-          border="2px solid"
-          borderColor="bauhaus.black"
-          borderRadius="0"
-          _hover={{
-            bg: "bauhaus.red",
-            transform: "translateY(-1px)",
-          }}
-          _active={{
-            transform: "translate(2px, 2px)",
-          }}
-          _disabled={{
-            opacity: 0.5,
-            cursor: "not-allowed",
-            _hover: { bg: "bauhaus.blue", transform: "none" },
-          }}
-        />
+        {isLoading && onCancel ? (
+          <IconButton
+            aria-label="Stop generation"
+            icon={<SmallCloseIcon boxSize={5} />}
+            onClick={onCancel}
+            bg="bauhaus.red"
+            color="bauhaus.white"
+            border="2px solid"
+            borderColor="bauhaus.black"
+            borderRadius="0"
+            _hover={{
+              bg: "bauhaus.black",
+              transform: "translateY(-1px)",
+            }}
+            _active={{
+              transform: "translate(2px, 2px)",
+            }}
+          />
+        ) : (
+          <IconButton
+            aria-label="Send message"
+            icon={<ArrowForwardIcon />}
+            onClick={handleSend}
+            isDisabled={!input.trim() || isLoading}
+            bg="bauhaus.blue"
+            color="bauhaus.white"
+            border="2px solid"
+            borderColor="bauhaus.black"
+            borderRadius="0"
+            _hover={{
+              bg: "bauhaus.red",
+              transform: "translateY(-1px)",
+            }}
+            _active={{
+              transform: "translate(2px, 2px)",
+            }}
+            _disabled={{
+              opacity: 0.5,
+              cursor: "not-allowed",
+              _hover: { bg: "bauhaus.blue", transform: "none" },
+            }}
+          />
+        )}
       </HStack>
     </Box>
   );

--- a/apps/extension/src/components/Chat/ChatList.tsx
+++ b/apps/extension/src/components/Chat/ChatList.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   Button,
   Tooltip,
+  Badge,
 } from "@chakra-ui/react";
 import { ArrowBackIcon, AddIcon, ChatIcon, DeleteIcon, StarIcon } from "@chakra-ui/icons";
 import { Conversation } from "@/chrome/chatStorage";
@@ -18,6 +19,13 @@ interface ChatListProps {
   onNewChat: () => void;
   onDeleteConversation: (id: string) => void;
   onToggleFavorite: (id: string) => void;
+  showAllAddresses?: boolean;
+  onToggleShowAll?: () => void;
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
 
 function formatTimestamp(timestamp: number): string {
@@ -50,6 +58,8 @@ export function ChatList({
   onNewChat,
   onDeleteConversation,
   onToggleFavorite,
+  showAllAddresses = false,
+  onToggleShowAll,
 }: ChatListProps) {
   return (
     <Box h="100%" display="flex" flexDirection="column" bg="bg.base">
@@ -111,6 +121,31 @@ export function ChatList({
           onClick={onNewChat}
         />
       </Flex>
+
+      {/* All Wallets Toggle */}
+      {onToggleShowAll && (
+        <HStack px={3} py={2} spacing={2} borderBottom="2px solid" borderColor="gray.200">
+          <Text fontSize="xs" fontWeight="700" color="text.secondary" textTransform="uppercase" letterSpacing="wide" flex="1">
+            All wallets
+          </Text>
+          <Button
+            size="xs"
+            bg={showAllAddresses ? "bauhaus.yellow" : "gray.200"}
+            color="bauhaus.black"
+            border="2px solid"
+            borderColor="bauhaus.black"
+            borderRadius="0"
+            fontWeight="700"
+            fontSize="10px"
+            textTransform="uppercase"
+            h="22px"
+            _hover={{ opacity: 0.8 }}
+            onClick={onToggleShowAll}
+          >
+            {showAllAddresses ? "ON" : "OFF"}
+          </Button>
+        </HStack>
+      )}
 
       {/* Conversation List */}
       <Box flex="1" overflowY="auto" p={3}>
@@ -234,13 +269,31 @@ export function ChatList({
                   >
                     {conv.title}
                   </Text>
-                  <Text
-                    fontSize="xs"
-                    color="text.tertiary"
-                    fontWeight="500"
-                  >
-                    {formatTimestamp(conv.updatedAt)}
-                  </Text>
+                  <HStack spacing={2}>
+                    <Text
+                      fontSize="xs"
+                      color="text.tertiary"
+                      fontWeight="500"
+                    >
+                      {formatTimestamp(conv.updatedAt)}
+                    </Text>
+                    {showAllAddresses && conv.address && (
+                      <Badge
+                        bg="gray.100"
+                        color="text.secondary"
+                        border="1px solid"
+                        borderColor="gray.300"
+                        fontSize="10px"
+                        fontWeight="600"
+                        fontFamily="mono"
+                        px={1}
+                        py={0}
+                        borderRadius="0"
+                      >
+                        {truncateAddress(conv.address)}
+                      </Badge>
+                    )}
+                  </HStack>
                 </Box>
 
                 {/* Delete Button */}

--- a/apps/extension/src/components/Chat/ChatView.tsx
+++ b/apps/extension/src/components/Chat/ChatView.tsx
@@ -13,17 +13,23 @@ interface ChatViewProps {
   onUnlock?: (conversationId?: string) => void;
   isWalletUnlocked?: boolean;
   onWalletLocked?: () => void;
+  address?: string;
+  chainId?: number;
 }
 
 type ChatMode = "list" | "chat";
 
-export function ChatView({ onBack, startWithNewChat = false, returnToConversationId, onUnlock, isWalletUnlocked, onWalletLocked }: ChatViewProps) {
+export function ChatView({ onBack, startWithNewChat = false, returnToConversationId, onUnlock, isWalletUnlocked, onWalletLocked, address, chainId }: ChatViewProps) {
   const {
     conversations,
     currentConversation,
     messages,
     isLoading,
     statusUpdateText,
+    streamContent,
+    showAllAddresses,
+    cancelChat,
+    setShowAllAddresses,
     sendMessage,
     loadConversation,
     createNewChat,
@@ -31,7 +37,7 @@ export function ChatView({ onBack, startWithNewChat = false, returnToConversatio
     toggleFavorite,
     refreshConversations,
     retryLastMessage,
-  } = useChat();
+  } = useChat({ address, chainId });
 
   // Determine initial mode based on props
   const getInitialMode = (): ChatMode => {
@@ -171,6 +177,8 @@ export function ChatView({ onBack, startWithNewChat = false, returnToConversatio
         onNewChat={handleNewChat}
         onDeleteConversation={handleDeleteConversation}
         onToggleFavorite={handleToggleFavorite}
+        showAllAddresses={showAllAddresses}
+        onToggleShowAll={() => setShowAllAddresses(!showAllAddresses)}
       />
     );
   }
@@ -191,6 +199,7 @@ export function ChatView({ onBack, startWithNewChat = false, returnToConversatio
           messages={messages}
           isLoading={isLoading}
           statusUpdateText={statusUpdateText}
+          streamContent={streamContent}
           isWalletUnlocked={isWalletUnlocked}
           onUnlock={handleUnlock}
           onRetry={retryLastMessage}
@@ -198,7 +207,7 @@ export function ChatView({ onBack, startWithNewChat = false, returnToConversatio
         />
 
         <Box w="100%" p={2} borderTop="2px solid" borderColor="bauhaus.black">
-          <ChatInput onSend={sendMessage} isLoading={isLoading} />
+          <ChatInput onSend={sendMessage} isLoading={isLoading} onCancel={cancelChat} />
         </Box>
       </VStack>
     </Box>

--- a/apps/extension/src/components/Chat/MessageBubble.tsx
+++ b/apps/extension/src/components/Chat/MessageBubble.tsx
@@ -1,58 +1,187 @@
 import { useState } from "react";
-import { Box, Text, Link, Button, HStack, IconButton } from "@chakra-ui/react";
+import { Box, Text, Link, Button, HStack, IconButton, Code, ListItem, UnorderedList, OrderedList } from "@chakra-ui/react";
 import { LockIcon, RepeatIcon, CopyIcon, CheckIcon } from "@chakra-ui/icons";
 import { Message } from "@/chrome/chatStorage";
 import ShapesLoader from "./ShapesLoader";
 
-
-// URL regex pattern
-const URL_REGEX = /(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/g;
-
 /**
- * Parse text and convert URLs to clickable links
+ * Parse inline markdown (bold, italic, code, links) within a single line.
  */
-function parseContentWithLinks(
-  content: string,
-  linkColor: string
+function parseInlineMarkdown(
+  text: string,
+  linkColor: string,
+  keyPrefix: string
 ): React.ReactNode[] {
-  const parts = content.split(URL_REGEX);
+  // Order matters: bold before italic, code before both
+  const inlineRegex = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))|(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/g;
+  const result: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
 
-  return parts.map((part, index) => {
-    if (URL_REGEX.test(part)) {
-      // Reset regex lastIndex since we're reusing it
-      URL_REGEX.lastIndex = 0;
-      return (
-        <Link
-          key={index}
-          href={part}
-          isExternal
-          color={linkColor}
-          textDecoration="underline"
-          fontWeight="600"
-          _hover={{ opacity: 0.8 }}
-          onClick={(e) => {
-            e.preventDefault();
-            chrome.tabs.create({ url: part });
-          }}
-        >
-          {part}
+  while ((match = inlineRegex.exec(text)) !== null) {
+    // Add text before match
+    if (match.index > lastIndex) {
+      result.push(text.slice(lastIndex, match.index));
+    }
+    const m = match[0];
+    const key = `${keyPrefix}-${match.index}`;
+
+    if (match[1]) {
+      // Inline code: `code`
+      result.push(
+        <Code key={key} bg="blackAlpha.200" px={1} py={0.5} fontSize="xs" fontWeight="600" borderRadius="2px">
+          {m.slice(1, -1)}
+        </Code>
+      );
+    } else if (match[2]) {
+      // Bold: **text**
+      result.push(<Text as="span" key={key} fontWeight="800">{m.slice(2, -2)}</Text>);
+    } else if (match[3]) {
+      // Italic: *text*
+      result.push(<Text as="span" key={key} fontStyle="italic">{m.slice(1, -1)}</Text>);
+    } else if (match[4]) {
+      // Markdown link: [text](url)
+      const linkMatch = /\[([^\]]+)\]\(([^)]+)\)/.exec(m);
+      if (linkMatch) {
+        result.push(
+          <Link key={key} href={linkMatch[2]} isExternal color={linkColor} textDecoration="underline" fontWeight="600" _hover={{ opacity: 0.8 }}
+            onClick={(e) => { e.preventDefault(); chrome.tabs.create({ url: linkMatch[2] }); }}>
+            {linkMatch[1]}
+          </Link>
+        );
+      }
+    } else if (match[5]) {
+      // Plain URL
+      result.push(
+        <Link key={key} href={m} isExternal color={linkColor} textDecoration="underline" fontWeight="600" _hover={{ opacity: 0.8 }}
+          onClick={(e) => { e.preventDefault(); chrome.tabs.create({ url: m }); }}>
+          {m}
         </Link>
       );
     }
-    return part;
-  });
+    lastIndex = match.index + m.length;
+  }
+
+  if (lastIndex < text.length) {
+    result.push(text.slice(lastIndex));
+  }
+
+  return result.length > 0 ? result : [text];
+}
+
+/**
+ * Render markdown content as React nodes.
+ * Supports: bold, italic, inline code, code blocks, lists, headers, links, URLs.
+ */
+function renderMarkdown(content: string, linkColor: string): React.ReactNode {
+  const lines = content.split("\n");
+  const elements: React.ReactNode[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block: ```
+    if (line.trimStart().startsWith("```")) {
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].trimStart().startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing ```
+      elements.push(
+        <Code key={`code-${i}`} display="block" bg="blackAlpha.200" p={2} my={1} fontSize="xs" fontWeight="600" whiteSpace="pre-wrap" wordBreak="break-word" borderRadius="2px" w="100%">
+          {codeLines.join("\n")}
+        </Code>
+      );
+      continue;
+    }
+
+    // Headers: # ## ###
+    const headerMatch = line.match(/^(#{1,3})\s+(.+)$/);
+    if (headerMatch) {
+      const level = headerMatch[1].length;
+      const sizes = ["md", "sm", "sm"] as const;
+      elements.push(
+        <Text key={`h-${i}`} fontWeight="900" fontSize={sizes[level - 1]} mt={level === 1 ? 1 : 0.5} mb={0.5}>
+          {parseInlineMarkdown(headerMatch[2], linkColor, `h${i}`)}
+        </Text>
+      );
+      i++;
+      continue;
+    }
+
+    // Unordered list items: - or *
+    if (/^\s*[-*]\s+/.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^\s*[-*]\s+/.test(lines[i])) {
+        const itemText = lines[i].replace(/^\s*[-*]\s+/, "");
+        items.push(
+          <ListItem key={`li-${i}`} fontSize="sm" fontWeight="500">
+            {parseInlineMarkdown(itemText, linkColor, `li${i}`)}
+          </ListItem>
+        );
+        i++;
+      }
+      elements.push(
+        <UnorderedList key={`ul-${i}`} pl={2} my={0.5} spacing={0.5}>
+          {items}
+        </UnorderedList>
+      );
+      continue;
+    }
+
+    // Ordered list items: 1. 2. etc
+    if (/^\s*\d+\.\s+/.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
+        const itemText = lines[i].replace(/^\s*\d+\.\s+/, "");
+        items.push(
+          <ListItem key={`oli-${i}`} fontSize="sm" fontWeight="500">
+            {parseInlineMarkdown(itemText, linkColor, `oli${i}`)}
+          </ListItem>
+        );
+        i++;
+      }
+      elements.push(
+        <OrderedList key={`ol-${i}`} pl={2} my={0.5} spacing={0.5}>
+          {items}
+        </OrderedList>
+      );
+      continue;
+    }
+
+    // Empty line → small spacer
+    if (line.trim() === "") {
+      elements.push(<Box key={`sp-${i}`} h={1} />);
+      i++;
+      continue;
+    }
+
+    // Regular paragraph
+    elements.push(
+      <Text key={`p-${i}`} fontSize="sm" fontWeight="500" lineHeight="1.5">
+        {parseInlineMarkdown(line, linkColor, `p${i}`)}
+      </Text>
+    );
+    i++;
+  }
+
+  return <>{elements}</>;
 }
 
 interface MessageBubbleProps {
   message: Message;
   statusText?: string | null;
+  streamContent?: string | null;
   isWalletUnlocked?: boolean;
   onUnlock?: () => void;
   onRetry?: () => void;
   onResend?: (content: string) => void;
 }
 
-export function MessageBubble({ message, statusText, isWalletUnlocked, onUnlock, onRetry, onResend }: MessageBubbleProps) {
+export function MessageBubble({ message, statusText, streamContent, isWalletUnlocked, onUnlock, onRetry, onResend }: MessageBubbleProps) {
   const [copied, setCopied] = useState(false);
   const isUser = message.role === "user";
   const isPending = message.status === "pending";
@@ -75,8 +204,44 @@ export function MessageBubble({ message, statusText, isWalletUnlocked, onUnlock,
 
   const styles = isError ? errorStyles : isUser ? userStyles : assistantStyles;
 
-  // Compact loader for pending state
+  // Pending state — show streaming content if available, else show loader
   if (isPending) {
+    // Streaming content: show the response as it arrives
+    if (streamContent) {
+      return (
+        <Box display="flex" justifyContent="flex-start" mb={2}>
+          <Box
+            maxW="90%"
+            bg="bauhaus.yellow"
+            color="bauhaus.black"
+            border="2px solid"
+            borderColor="bauhaus.black"
+            boxShadow="3px 3px 0px 0px #121212"
+            p={2}
+            position="relative"
+          >
+            <Box
+              position="absolute"
+              top="-4px"
+              left="-4px"
+              w="8px"
+              h="8px"
+              bg="bauhaus.red"
+              border="1.5px solid"
+              borderColor="bauhaus.black"
+            />
+            <Box wordBreak="break-word">
+              {renderMarkdown(streamContent, "bauhaus.blue")}
+            </Box>
+            <HStack spacing={2} mt={1}>
+              <ShapesLoader size="8px" />
+            </HStack>
+          </Box>
+        </Box>
+      );
+    }
+
+    // No streaming content yet — show compact loader with status text
     return (
       <Box
         display="flex"
@@ -204,18 +369,15 @@ export function MessageBubble({ message, statusText, isWalletUnlocked, onUnlock,
           borderColor="bauhaus.black"
         />
 
-        <Text
-          fontWeight="500"
-          fontSize="sm"
-          lineHeight="1.5"
-          whiteSpace="pre-wrap"
-          wordBreak="break-word"
-        >
-          {parseContentWithLinks(
-            message.content,
-            isUser ? "bauhaus.yellow" : "bauhaus.blue"
+        <Box wordBreak="break-word">
+          {isUser ? (
+            <Text fontWeight="500" fontSize="sm" lineHeight="1.5" whiteSpace="pre-wrap">
+              {message.content}
+            </Text>
+          ) : (
+            renderMarkdown(message.content, isUser ? "bauhaus.yellow" : "bauhaus.blue")
           )}
-        </Text>
+        </Box>
 
         <HStack justify="space-between" align="center" mt={2}>
           <HStack spacing={1}>

--- a/apps/extension/src/components/Chat/MessageList.tsx
+++ b/apps/extension/src/components/Chat/MessageList.tsx
@@ -7,19 +7,20 @@ interface MessageListProps {
   messages: Message[];
   isLoading?: boolean;
   statusUpdateText?: string | null;
+  streamContent?: string | null;
   isWalletUnlocked?: boolean;
   onUnlock?: () => void;
   onRetry?: () => void;
   onResend?: (content: string) => void;
 }
 
-export function MessageList({ messages, isLoading, statusUpdateText, isWalletUnlocked, onUnlock, onRetry, onResend }: MessageListProps) {
+export function MessageList({ messages, isLoading, statusUpdateText, streamContent, isWalletUnlocked, onUnlock, onRetry, onResend }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // Auto-scroll to bottom when messages change
+  // Auto-scroll to bottom when messages change or content streams in
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, isLoading]);
+  }, [messages, isLoading, streamContent]);
 
   if (messages.length === 0) {
     return (
@@ -94,6 +95,7 @@ export function MessageList({ messages, isLoading, statusUpdateText, isWalletUnl
             key={message.id}
             message={message}
             statusText={message.status === "pending" ? statusUpdateText : undefined}
+            streamContent={message.status === "pending" ? streamContent : undefined}
             isWalletUnlocked={isWalletUnlocked}
             onUnlock={onUnlock}
             onRetry={onRetry}

--- a/apps/extension/src/components/Settings/OllamaSettings.tsx
+++ b/apps/extension/src/components/Settings/OllamaSettings.tsx
@@ -1,0 +1,347 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  VStack,
+  HStack,
+  Text,
+  Input,
+  IconButton,
+  Spacer,
+  Button,
+  Badge,
+  Code,
+} from "@chakra-ui/react";
+import { useBauhausToast } from "@/hooks/useBauhausToast";
+import { ArrowBackIcon } from "@chakra-ui/icons";
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  DEFAULT_OLLAMA_MODEL,
+} from "@/constants/externalUrls";
+
+interface OllamaSettingsProps {
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+interface OllamaSettings {
+  enabled: boolean;
+  baseUrl: string;
+  modelName: string;
+}
+
+function OllamaSettings({ onCancel }: OllamaSettingsProps) {
+  const [settings, setSettings] = useState<OllamaSettings>({
+    enabled: false,
+    baseUrl: DEFAULT_OLLAMA_BASE_URL,
+    modelName: DEFAULT_OLLAMA_MODEL,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [isTesting, setIsTesting] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<
+    "unknown" | "connected" | "error"
+  >("unknown");
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const toast = useBauhausToast();
+
+  useEffect(() => {
+    chrome.runtime.sendMessage({ type: "getOllamaSettings" }, (response) => {
+      if (response) {
+        setSettings(response);
+      }
+      setIsLoading(false);
+    });
+  }, []);
+
+  const saveSettings = (updates: Partial<OllamaSettings>) => {
+    const updated = { ...settings, ...updates };
+    setSettings(updated);
+    chrome.runtime.sendMessage({
+      type: "saveOllamaSettings",
+      settings: updated,
+    });
+  };
+
+  const testConnection = () => {
+    setIsTesting(true);
+    setConnectionStatus("unknown");
+    chrome.runtime.sendMessage(
+      { type: "checkOllamaAvailability", baseUrl: settings.baseUrl },
+      (response) => {
+        setIsTesting(false);
+        if (response?.available) {
+          setConnectionStatus("connected");
+          setAvailableModels(response.models || []);
+          const hasModel = (response.models || []).some((m: string) =>
+            m.startsWith(settings.modelName)
+          );
+          toast({
+            title: hasModel
+              ? "Connected — model found"
+              : `Connected — model "${settings.modelName}" not found`,
+            description: hasModel
+              ? undefined
+              : `Available: ${response.models.join(", ") || "none"}`,
+            status: hasModel ? "success" : "warning",
+            duration: 3000,
+            isClosable: true,
+          });
+        } else {
+          setConnectionStatus("error");
+          setAvailableModels([]);
+          toast({
+            title: "Cannot reach Ollama",
+            description: "Make sure Ollama is running with `ollama serve`",
+            status: "error",
+            duration: 4000,
+            isClosable: true,
+          });
+        }
+      }
+    );
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {/* Header */}
+      <HStack>
+        <IconButton
+          aria-label="Back"
+          icon={<ArrowBackIcon />}
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+        />
+        <Text
+          fontSize="lg"
+          fontWeight="900"
+          color="text.primary"
+          textTransform="uppercase"
+          letterSpacing="tight"
+        >
+          Local AI Chat
+        </Text>
+        <Spacer />
+      </HStack>
+
+      <Text fontSize="sm" color="text.secondary" fontWeight="500">
+        Use a local Ollama model for AI chat on Private Key and Seed Phrase
+        accounts.
+      </Text>
+
+      {/* Enable Toggle */}
+      <Box
+        bg="bauhaus.white"
+        border="3px solid"
+        borderColor="bauhaus.black"
+        boxShadow="4px 4px 0px 0px #121212"
+        p={4}
+      >
+        <HStack justify="space-between">
+          <Box>
+            <Text fontWeight="700" color="text.primary">
+              Enable Local AI
+            </Text>
+            <Text fontSize="xs" color="text.secondary" fontWeight="500">
+              Chat with Nani via Ollama
+            </Text>
+          </Box>
+          <Button
+            size="sm"
+            bg={settings.enabled ? "bauhaus.yellow" : "gray.200"}
+            color="bauhaus.black"
+            border="2px solid"
+            borderColor="bauhaus.black"
+            borderRadius="0"
+            fontWeight="700"
+            fontSize="xs"
+            textTransform="uppercase"
+            _hover={{ opacity: 0.8 }}
+            onClick={() => saveSettings({ enabled: !settings.enabled })}
+          >
+            {settings.enabled ? "ON" : "OFF"}
+          </Button>
+        </HStack>
+      </Box>
+
+      {/* Connection Settings */}
+      <Box
+        bg="bauhaus.white"
+        border="3px solid"
+        borderColor="bauhaus.black"
+        boxShadow="4px 4px 0px 0px #121212"
+        p={4}
+        opacity={settings.enabled ? 1 : 0.5}
+        pointerEvents={settings.enabled ? "auto" : "none"}
+      >
+        <VStack spacing={3} align="stretch">
+          <Box>
+            <Text fontWeight="700" color="text.primary" fontSize="sm" mb={1}>
+              Ollama URL
+            </Text>
+            <Input
+              value={settings.baseUrl}
+              onChange={(e) => {
+                setSettings({ ...settings, baseUrl: e.target.value });
+                setConnectionStatus("unknown");
+              }}
+              onBlur={() => saveSettings({ baseUrl: settings.baseUrl })}
+              placeholder={DEFAULT_OLLAMA_BASE_URL}
+              bg="bauhaus.white"
+              border="3px solid"
+              borderColor="bauhaus.black"
+              fontWeight="600"
+              fontSize="sm"
+              fontFamily="mono"
+              _hover={{ borderColor: "bauhaus.black" }}
+              _focus={{ borderColor: "bauhaus.blue", boxShadow: "none" }}
+            />
+          </Box>
+
+          <Box>
+            <Text fontWeight="700" color="text.primary" fontSize="sm" mb={1}>
+              Model Name
+            </Text>
+            <Input
+              value={settings.modelName}
+              onChange={(e) => {
+                setSettings({ ...settings, modelName: e.target.value });
+                setConnectionStatus("unknown");
+              }}
+              onBlur={() => saveSettings({ modelName: settings.modelName })}
+              placeholder={DEFAULT_OLLAMA_MODEL}
+              bg="bauhaus.white"
+              border="3px solid"
+              borderColor="bauhaus.black"
+              fontWeight="600"
+              fontSize="sm"
+              _hover={{ borderColor: "bauhaus.black" }}
+              _focus={{ borderColor: "bauhaus.blue", boxShadow: "none" }}
+            />
+          </Box>
+
+          {/* Test Connection */}
+          <HStack spacing={2}>
+            <Button
+              onClick={testConnection}
+              isLoading={isTesting}
+              loadingText="Testing..."
+              bg="bauhaus.blue"
+              color="white"
+              border="3px solid"
+              borderColor="bauhaus.black"
+              boxShadow="3px 3px 0px 0px #121212"
+              borderRadius="0"
+              fontWeight="700"
+              fontSize="sm"
+              textTransform="uppercase"
+              _hover={{
+                transform: "translateY(-1px)",
+                boxShadow: "4px 4px 0px 0px #121212",
+              }}
+              _active={{
+                transform: "translate(1px, 1px)",
+                boxShadow: "none",
+              }}
+            >
+              Test Connection
+            </Button>
+            {connectionStatus === "connected" && (
+              <Badge
+                bg="green.100"
+                color="green.700"
+                border="2px solid"
+                borderColor="green.500"
+                fontWeight="700"
+                fontSize="xs"
+              >
+                Connected
+              </Badge>
+            )}
+            {connectionStatus === "error" && (
+              <Badge
+                bg="red.100"
+                color="red.700"
+                border="2px solid"
+                borderColor="red.500"
+                fontWeight="700"
+                fontSize="xs"
+              >
+                Not Reachable
+              </Badge>
+            )}
+          </HStack>
+
+          {/* Available models */}
+          {connectionStatus === "connected" && availableModels.length > 0 && (
+            <Box>
+              <Text fontSize="xs" color="text.secondary" fontWeight="600" mb={1}>
+                Available models:
+              </Text>
+              <Text fontSize="xs" color="text.secondary" fontFamily="mono">
+                {availableModels.join(", ")}
+              </Text>
+            </Box>
+          )}
+        </VStack>
+      </Box>
+
+      {/* Setup Guide */}
+      <Box
+        bg="bauhaus.yellow"
+        border="3px solid"
+        borderColor="bauhaus.black"
+        boxShadow="4px 4px 0px 0px #121212"
+        p={4}
+      >
+        <Text fontWeight="700" color="bauhaus.black" fontSize="sm" mb={2}>
+          Setup Guide
+        </Text>
+        <VStack spacing={1} align="stretch">
+          <Text fontSize="xs" color="bauhaus.black" fontWeight="500">
+            1. Install Ollama from{" "}
+            <Text as="span" fontWeight="700">
+              ollama.com
+            </Text>
+          </Text>
+          <Text fontSize="xs" color="bauhaus.black" fontWeight="500">
+            2. Pull the nani model:
+          </Text>
+          <Code
+            bg="bauhaus.black"
+            color="bauhaus.yellow"
+            p={2}
+            fontSize="xs"
+            fontWeight="600"
+          >
+            ollama pull hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M
+          </Code>
+          <Code
+            bg="bauhaus.black"
+            color="bauhaus.yellow"
+            p={2}
+            fontSize="xs"
+            fontWeight="600"
+          >
+            ollama cp hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M nani
+          </Code>
+          <Text fontSize="xs" color="bauhaus.black" fontWeight="500">
+            3. Start Ollama (must allow extension origin):
+          </Text>
+          <Code
+            bg="bauhaus.black"
+            color="bauhaus.yellow"
+            p={2}
+            fontSize="xs"
+            fontWeight="600"
+          >
+            OLLAMA_ORIGINS=* ollama serve
+          </Code>
+        </VStack>
+      </Box>
+    </VStack>
+  );
+}
+
+export default OllamaSettings;

--- a/apps/extension/src/components/Settings/index.tsx
+++ b/apps/extension/src/components/Settings/index.tsx
@@ -35,6 +35,7 @@ import Chains from "./Chains";
 import ChangePassword from "./ChangePassword";
 import AutoLockSettings from "./AutoLockSettings";
 import AgentPasswordSettings from "./AgentPasswordSettings";
+import OllamaSettings from "./OllamaSettings";
 
 // Robot/Agent icon for Agent Password section
 const AgentIcon = (props: any) => (
@@ -46,7 +47,7 @@ const AgentIcon = (props: any) => (
   </Icon>
 );
 
-type SettingsTab = "main" | "chains" | "changePassword" | "autoLock" | "agentPassword";
+type SettingsTab = "main" | "chains" | "changePassword" | "autoLock" | "agentPassword" | "ollama";
 
 interface SettingsProps {
   close: () => void;
@@ -166,6 +167,15 @@ function Settings({
         }}
         onCancel={() => setTab("main")}
         onSessionExpired={onSessionExpired || (() => setTab("main"))}
+      />
+    );
+  }
+
+  if (tab === "ollama") {
+    return (
+      <OllamaSettings
+        onComplete={() => setTab("main")}
+        onCancel={() => setTab("main")}
       />
     );
   }
@@ -352,6 +362,58 @@ function Settings({
               </Text>
               <Text fontSize="xs" color="text.secondary" fontWeight="500">
                 Configure wallet lock timeout
+              </Text>
+            </Box>
+          </HStack>
+          <Box bg="bauhaus.black" p={1}>
+            <ChevronRightIcon color="bauhaus.white" />
+          </Box>
+        </HStack>
+      </Box>
+
+      {/* Local AI Chat (Ollama) Section */}
+      <Box
+        bg="bauhaus.white"
+        border="3px solid"
+        borderColor="bauhaus.black"
+        boxShadow="4px 4px 0px 0px #121212"
+        p={4}
+        cursor="pointer"
+        onClick={() => setTab("ollama")}
+        _hover={{
+          transform: "translateY(-2px)",
+          boxShadow: "6px 6px 0px 0px #121212",
+        }}
+        _active={{
+          transform: "translate(2px, 2px)",
+          boxShadow: "none",
+        }}
+        transition="all 0.2s ease-out"
+        position="relative"
+      >
+        {/* Corner decoration */}
+        <Box
+          position="absolute"
+          top="-3px"
+          right="-3px"
+          w="8px"
+          h="8px"
+          bg="bauhaus.green"
+          border="2px solid"
+          borderColor="bauhaus.black"
+        />
+
+        <HStack justify="space-between">
+          <HStack spacing={3}>
+            <Box p={2} bg="bauhaus.green">
+              <ChatIcon boxSize={4} color="bauhaus.black" />
+            </Box>
+            <Box>
+              <Text fontWeight="700" color="text.primary">
+                Local AI Chat
+              </Text>
+              <Text fontSize="xs" color="text.secondary" fontWeight="500">
+                Configure Ollama for PK/SP accounts
               </Text>
             </Box>
           </HStack>

--- a/apps/extension/src/constants/externalUrls.ts
+++ b/apps/extension/src/constants/externalUrls.ts
@@ -76,6 +76,12 @@ export const USDC_LOGO_URL =
   "https://coin-images.coingecko.com/coins/images/6319/small/usdc.png";
 
 // ---------------------------------------------------------------------------
+// Local AI (Ollama)
+// ---------------------------------------------------------------------------
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+export const DEFAULT_OLLAMA_MODEL = "nani";
+
+// ---------------------------------------------------------------------------
 // IPFS Gateway
 // ---------------------------------------------------------------------------
 export const IPFS_GATEWAY = "https://ipfs.io/ipfs/";

--- a/apps/extension/src/hooks/useChat.ts
+++ b/apps/extension/src/hooks/useChat.ts
@@ -3,6 +3,7 @@ import {
   Message,
   Conversation,
   getConversations,
+  getConversationsForAddress,
   getConversation,
   createConversation,
   deleteConversation,
@@ -12,6 +13,11 @@ import {
   deleteMessageFromConversation,
 } from "@/chrome/chatStorage";
 
+interface UseChatOptions {
+  address?: string;
+  chainId?: number;
+}
+
 interface UseChatReturn {
   conversations: Conversation[];
   currentConversation: Conversation | null;
@@ -19,6 +25,9 @@ interface UseChatReturn {
   isLoading: boolean;
   error: string | null;
   statusUpdateText: string | null;
+  streamContent: string | null;
+  showAllAddresses: boolean;
+  setShowAllAddresses: (show: boolean) => void;
   sendMessage: (content: string) => Promise<void>;
   loadConversation: (id: string) => Promise<void>;
   createNewChat: () => Promise<Conversation>;
@@ -26,21 +35,37 @@ interface UseChatReturn {
   toggleFavorite: (id: string) => Promise<void>;
   refreshConversations: () => Promise<void>;
   retryLastMessage: () => Promise<void>;
+  cancelChat: () => void;
 }
 
-export function useChat(): UseChatReturn {
+export function useChat(options?: UseChatOptions): UseChatReturn {
+  const address = options?.address;
+  const chainId = options?.chainId;
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [currentConversation, setCurrentConversation] = useState<Conversation | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusUpdateText, setStatusUpdateText] = useState<string | null>(null);
+  const [streamContent, setStreamContent] = useState<string | null>(null);
   // Track if current conversation is unsaved (only in memory)
   const [isUnsavedChat, setIsUnsavedChat] = useState(false);
+  // Toggle between showing only current address's chats vs all
+  const [showAllAddresses, setShowAllAddresses] = useState(false);
 
-  // Load conversations on mount
+  const refreshConversations = useCallback(async () => {
+    if (address && !showAllAddresses) {
+      const convs = await getConversationsForAddress(address);
+      setConversations(convs);
+    } else {
+      const convs = await getConversations();
+      setConversations(convs);
+    }
+  }, [address, showAllAddresses]);
+
+  // Load conversations on mount and when filter changes
   useEffect(() => {
     refreshConversations();
-  }, []);
+  }, [refreshConversations]);
 
   // Listen for chat updates from background
   useEffect(() => {
@@ -52,13 +77,15 @@ export function useChat(): UseChatReturn {
         content?: string;
         error?: string;
         statusUpdates?: Array<{ message: string; timestamp: string }>;
+        streamContent?: string;
       },
       _sender: chrome.runtime.MessageSender,
       sendResponse: (response?: any) => void
     ) => {
       if (message.type === "chatJobComplete" && message.conversationId) {
-        // Clear status update text on completion
+        // Clear status/stream text on completion
         setStatusUpdateText(null);
+        setStreamContent(null);
         // Update the message with the response
         if (currentConversation?.id === message.conversationId && message.messageId) {
           updateMessageInConversation(message.conversationId, message.messageId, {
@@ -75,10 +102,16 @@ export function useChat(): UseChatReturn {
       }
 
       if (message.type === "chatJobUpdate" && message.conversationId) {
-        // Extract the latest status update message
+        // Handle streaming content from Ollama
+        if (message.streamContent !== undefined) {
+          setStreamContent(message.streamContent);
+          setStatusUpdateText(null); // Clear status text when streaming
+        }
+        // Extract the latest status update message (Bankr API or tool execution)
         if (message.statusUpdates && message.statusUpdates.length > 0) {
           const latest = message.statusUpdates[message.statusUpdates.length - 1];
           setStatusUpdateText(latest.message);
+          setStreamContent(null); // Clear stream when showing status
         }
         // Refresh conversation to get latest state
         if (currentConversation?.id === message.conversationId) {
@@ -94,11 +127,6 @@ export function useChat(): UseChatReturn {
     chrome.runtime.onMessage.addListener(handleMessage);
     return () => chrome.runtime.onMessage.removeListener(handleMessage);
   }, [currentConversation?.id]);
-
-  const refreshConversations = useCallback(async () => {
-    const convs = await getConversations();
-    setConversations(convs);
-  }, []);
 
   const loadConversation = useCallback(async (id: string) => {
     const conv = await getConversation(id);
@@ -150,6 +178,7 @@ export function useChat(): UseChatReturn {
 
       setError(null);
       setStatusUpdateText(null);
+      setStreamContent(null);
       let conv = currentConversation;
 
       // Create new conversation if none exists
@@ -177,9 +206,10 @@ export function useChat(): UseChatReturn {
 
       // If this is an unsaved chat, persist it now with the first message
       if (isUnsavedChat) {
-        // Create the conversation in storage
+        // Create the conversation in storage (with address for filtering)
         const savedConv = await createConversation(
-          content.length > 50 ? content.substring(0, 50) + "..." : content
+          content.length > 50 ? content.substring(0, 50) + "..." : content,
+          address
         );
         // Update the ID to match the saved one
         conv = { ...savedConv, messages: [] };
@@ -220,6 +250,7 @@ export function useChat(): UseChatReturn {
               conversationId: conv!.id,
               messageId: assistantMessage.id,
               prompt: content,
+              chainId,
             },
             (res) => {
               if (chrome.runtime.lastError) {
@@ -237,7 +268,8 @@ export function useChat(): UseChatReturn {
         if (!response.success) {
           // Update message with error
           const errorContent = response.error || "Failed to send message";
-          const isWalletLocked = errorContent.includes("Wallet is locked");
+          const isWalletLocked = errorContent.includes("Wallet is locked") ||
+            errorContent.includes("not configured");
           await updateMessageInConversation(conv!.id, assistantMessage.id, {
             content: errorContent,
             status: "error",
@@ -269,7 +301,7 @@ export function useChat(): UseChatReturn {
 
       await refreshConversations();
     },
-    [currentConversation, isLoading, isUnsavedChat, refreshConversations]
+    [currentConversation, isLoading, isUnsavedChat, refreshConversations, address, chainId]
   );
 
   const retryLastMessage = useCallback(async () => {
@@ -328,6 +360,7 @@ export function useChat(): UseChatReturn {
             conversationId: currentConversation.id,
             messageId: assistantMessage.id,
             prompt: lastUserMessage.content,
+            chainId,
           },
           (res) => {
             if (chrome.runtime.lastError) {
@@ -374,7 +407,15 @@ export function useChat(): UseChatReturn {
     }
 
     await refreshConversations();
-  }, [currentConversation, isLoading, refreshConversations]);
+  }, [currentConversation, isLoading, refreshConversations, chainId]);
+
+  const cancelChat = useCallback(() => {
+    if (!currentConversation || !isLoading) return;
+    chrome.runtime.sendMessage({
+      type: "cancelOllamaChat",
+      conversationId: currentConversation.id,
+    });
+  }, [currentConversation, isLoading]);
 
   return {
     conversations,
@@ -383,6 +424,9 @@ export function useChat(): UseChatReturn {
     isLoading,
     error,
     statusUpdateText,
+    streamContent,
+    showAllAddresses,
+    setShowAllAddresses,
     sendMessage,
     loadConversation,
     createNewChat,
@@ -390,6 +434,7 @@ export function useChat(): UseChatReturn {
     toggleFavorite,
     refreshConversations,
     retryLastMessage,
+    cancelChat,
   };
 }
 


### PR DESCRIPTION
## Summary

- Local AI chat for Private Key and Seed Phrase accounts via [NaniDAO's nani-qwen-3.5-2B](https://huggingface.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km) model running on Ollama
- Bankr API chat unchanged for bankr accounts — routing by account type in `chatHandlers.ts`
- Streaming responses with `<think>` block hiding, stop generation button, markdown rendering
- Tool execution loop: balance checks, ENS resolution, price lookups, token transfers (user confirms via normal tx flow)
- Chat history tagged per wallet address with "All wallets" toggle
- Settings UI with enable toggle, connection test, setup guide

## Remaining work

- [ ] Test tool calling end-to-end (balance, ENS, transfer)
- [ ] Verify conversation history context works across multi-turn tool calls
- [ ] Add `intentSwap` tool
- [ ] Polish markdown rendering edge cases
- [ ] Test with different Ollama models
- [ ] Update `_docs/STORAGE.md` with `ollamaSettings` key

## Setup (for testing)

```bash
# Pull model + create with ChatML template
ollama pull hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M
ollama cp hf.co/NaniDAO/nani-qwen-3.5-2B-gguf-q4km:Q4_K_M nani
# Then create with Modelfile (see _docs/OLLAMA.md)

# Start with extension origin allowed
OLLAMA_ORIGINS=* ollama serve
```

Then in extension: Settings → Local AI Chat → Enable → Test Connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)