### PR TITLE
fix(extension): normalize Bankr typed-data chain IDs

### DIFF
--- a/_docs/IMPLEMENTATION.md
+++ b/_docs/IMPLEMENTATION.md
@@ -976,6 +976,9 @@ The SignatureRequestConfirmation component shows:
 
 - Sign button (yellow): Signs via `/wallet/sign` API
 - Reject button (white/secondary): Cancels the request
+- Before forwarding EIP-712 typed data, `bankrApi.ts` normalizes a decimal or
+  hexadecimal string `domain.chainId` to the positive safe JSON number required
+  by Bankr. Invalid or out-of-range chain IDs are rejected locally.
 
 **For Private Key / Seed Phrase Accounts:**
 

--- a/apps/extension/src/chrome/bankrApi.ts
+++ b/apps/extension/src/chrome/bankrApi.ts
@@ -3,6 +3,7 @@
  */
 
 import { BANKR_API_BASE } from "@/constants/externalUrls";
+import { normalizeBankrTypedDataChainId } from "./bankrApiUtils";
 
 const API_BASE_URL = BANKR_API_BASE;
 
@@ -269,6 +270,7 @@ export async function signMessageViaApi(
     if (typeof typedData === "string") {
       typedData = JSON.parse(typedData);
     }
+    typedData = normalizeBankrTypedDataChainId(typedData);
     body = { signatureType: "eth_signTypedData_v4", typedData };
   } else {
     throw new BankrApiError(`Unsupported signing method: ${method}`);

--- a/apps/extension/src/chrome/bankrApiUtils.ts
+++ b/apps/extension/src/chrome/bankrApiUtils.ts
@@ -1,0 +1,39 @@
+export class BankrTypedDataValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BankrTypedDataValidationError";
+  }
+}
+
+/**
+ * Bankr's signing API requires EIP-712 domain.chainId to be a JSON number,
+ * while dapps commonly send decimal or hex strings over JSON-RPC.
+ */
+export function normalizeBankrTypedDataChainId(typedData: any): any {
+  const rawChainId = typedData?.domain?.chainId;
+  if (rawChainId === undefined || rawChainId === null) return typedData;
+
+  if (typeof rawChainId === "number") {
+    if (!Number.isSafeInteger(rawChainId) || rawChainId <= 0) {
+      throw new BankrTypedDataValidationError("Invalid EIP-712 domain chainId");
+    }
+    return typedData;
+  }
+
+  const isSupportedString =
+    typeof rawChainId === "string" &&
+    (/^\d+$/.test(rawChainId) || /^0x[0-9a-f]+$/i.test(rawChainId));
+  if (!isSupportedString && typeof rawChainId !== "bigint") {
+    throw new BankrTypedDataValidationError("Invalid EIP-712 domain chainId");
+  }
+
+  const parsedChainId = BigInt(rawChainId);
+  if (parsedChainId <= 0n || parsedChainId > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new BankrTypedDataValidationError("EIP-712 domain chainId is out of range");
+  }
+
+  return {
+    ...typedData,
+    domain: { ...typedData.domain, chainId: Number(parsedChainId) },
+  };
+}


### PR DESCRIPTION
## Summary

Fixes Bankr API typed-data signing when a dapp supplies `domain.chainId` as a decimal or hexadecimal string.

Closes #8.

## Problem

Some dapps, including Uniswap Permit2 flows, serialize the EIP-712 domain chain ID as a string:

```json
{
  "chainId": "8453"
}
```

WalletChan forwarded this value unchanged to Bankr’s `/wallet/sign` endpoint, which expects a JSON number. Bankr rejected the request with:

```text
Expected number, received string
path: typedData.domain.chainId
```

## Solution

Before forwarding EIP-712 typed data to Bankr, WalletChan now:

- Converts decimal strings such as `"8453"` to `8453`.
- Converts hexadecimal strings such as `"0x2105"` to `8453`.
- Preserves chain IDs already represented as numbers.
- Does not mutate the original typed-data request.
- Rejects invalid, non-positive, fractional, or unsafe chain IDs locally.

This normalization applies only to Bankr API signing. Private-key and seed-phrase accounts continue using their existing local-signing paths.

## Testing

The extension was built and loaded locally. The following script was executed in the browser console to request an `eth_signTypedData_v4` signature with `domain.chainId` deliberately represented as a string:

```js
(async () => {
  const provider = await new Promise((resolve, reject) => {
    const timeout = setTimeout(
      () => reject(new Error("WalletChan provider not found")),
      3000
    );

    const onProvider = (event) => {
      if (event.detail?.info?.rdns === "com.walletchan") {
        clearTimeout(timeout);
        removeEventListener("eip6963:announceProvider", onProvider);
        resolve(event.detail.provider);
      }
    };

    addEventListener("eip6963:announceProvider", onProvider);
    dispatchEvent(new Event("eip6963:requestProvider"));
  });

  const [address] = await provider.request({
    method: "eth_requestAccounts",
  });

  await provider.request({
    method: "wallet_switchEthereumChain",
    params: [{ chainId: "0x2105" }], // Base
  });

  const typedData = {
    domain: {
      name: "WalletChan Signing Test",
      version: "1",
      chainId: "8453", // Deliberately a string
    },
    types: {
      EIP712Domain: [
        { name: "name", type: "string" },
        { name: "version", type: "string" },
        { name: "chainId", type: "uint256" },
      ],
      TestMessage: [
        { name: "contents", type: "string" },
      ],
    },
    primaryType: "TestMessage",
    message: {
      contents: "Testing WalletChan chainId normalization",
    },
  };

  try {
    const signature = await provider.request({
      method: "eth_signTypedData_v4",
      params: [address, JSON.stringify(typedData)],
    });

    console.log("PASS — signing succeeded:", signature);
  } catch (error) {
    console.error("FAIL — signing rejected:", error);
  }
})();
```